### PR TITLE
[FEATURE] Build and deploy Docker image for alternative usage

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,8 @@
 /.php-cs-fixer.php        export-ignore
 /codecov.yml              export-ignore
 /dependency-checker.json  export-ignore
+/docker-entrypoint.sh     export-ignore
+/Dockerfile               export-ignore
 /phpstan.neon             export-ignore
 /phpunit.xml              export-ignore
 /phpunit.coverage.xml     export-ignore

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,58 @@
+name: Docker deploy
+on:
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      # Check if tag is valid
+      - name: Check tag
+        run: |
+          if ! [[ ${{ github.ref }} =~ ^refs/tags/[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}$ ]]; then
+            echo ":rotating_light: This job can be executed only for tags." >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
+
+      # Generate metadata
+      - name: Generate image metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: cpsit/project-builder
+          tags: |
+            type=raw,value=latest,enable=${{ github.event_name != 'workflow_dispatch' }}
+            type=semver,pattern={{version}}
+            type=raw,value=${{ github.ref_name }},enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      # Prepare build
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      # Login at Docker Hub
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Build and push image
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            PROJECT_BUILDER_VERSION=${{ github.ref_name }}
+          tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM composer:2.3 AS composer
+LABEL maintainer="Elias Häußler <e.haeussler@familie-redlich.de>"
+
+FROM php:8.1-alpine
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+ADD . /project-builder
+WORKDIR /project-builder
+
+# Install Git and php-zip extension
+RUN apk update \
+    && apk add git libzip-dev zip \
+    && docker-php-ext-install zip
+
+# Build project-builder artifact for later use in entrypoint
+ARG PROJECT_BUILDER_VERSION=0.0.0
+RUN composer config version "$PROJECT_BUILDER_VERSION" \
+    && composer lint:composer \
+    && composer update --prefer-dist --no-dev \
+    && git add -f composer.lock \
+    && mkdir artifacts \
+    && git stash \
+    && git archive --format=tar --output="artifacts/project-builder-$PROJECT_BUILDER_VERSION.tar" "stash@{0}" \
+    && git stash pop
+
+WORKDIR /app
+ENTRYPOINT ["/project-builder/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/a84923d4d61c50561186/maintainability)](https://codeclimate.com/github/CPS-IT/project-builder/maintainability)
 [![Tests](https://github.com/CPS-IT/project-builder/actions/workflows/tests.yaml/badge.svg)](https://github.com/CPS-IT/project-builder/actions/workflows/tests.yaml)
 [![CGL](https://github.com/CPS-IT/project-builder/actions/workflows/cgl.yaml/badge.svg)](https://github.com/CPS-IT/project-builder/actions/workflows/cgl.yaml)
+[![Docker deploy](https://github.com/CPS-IT/project-builder/actions/workflows/docker.yaml/badge.svg)](https://github.com/CPS-IT/project-builder/actions/workflows/docker.yaml)
 [![Latest Stable Version](http://poser.pugx.org/cpsit/project-builder/v)](https://packagist.org/packages/cpsit/project-builder)
 [![Total Downloads](http://poser.pugx.org/cpsit/project-builder/downloads)](https://packagist.org/packages/cpsit/project-builder)
+[![Docker](https://img.shields.io/docker/v/cpsit/project-builder?label=docker&sort=semver)](https://hub.docker.com/r/cpsit/project-builder)
 [![License](http://poser.pugx.org/cpsit/project-builder/license)](LICENSE)
 
 :package:&nbsp;[Packagist](https://packagist.org/packages/cpsit/project-builder) |
@@ -33,8 +35,16 @@ easier to create new project repositories from command line.
 
 ## :zap: Usage
 
+Usage with [Composer][3]:
+
 ```bash
 composer create-project cpsit/project-builder <projectname>
+```
+
+Alternative usage with Docker:
+
+```bash
+docker run --rm -it -v <target-dir>:/app cpsit/project-builder
 ```
 
 Please have a look at [`Usage`](docs/usage.md) for an extended overview.
@@ -58,3 +68,4 @@ This project is licensed under [GNU General Public License 3.0 (or later)](LICEN
 
 [1]: https://www.cps-it.de
 [2]: https://getcomposer.org/doc/03-cli.md#create-project
+[3]: https://getcomposer.org/

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+set -e
+
+composer create-project "$@" \
+    --repository='{"type":"artifact","url":"/project-builder/artifacts"}' \
+    --prefer-dist \
+    --no-dev \
+    cpsit/project-builder \
+    /app

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,11 +1,20 @@
 # Usage
 
-## Requirements
+There are two ways this project can be used:
+
+* [Usage with Composer](#usage-with-composer) is the preferred way. It
+  requires a global Composer installation.
+* [Usage with Docker](#usage-with-docker) is an alternative way. The only
+  requirement with this method is a local Docker installation.
+
+## Usage with Composer
+
+### Requirements
 
 * Composer >= 2.1
 * PHP >= 7.4
 
-## Basic usage
+### Basic usage
 
 This project should always be used together with the [`create-project`][1]
 Composer command:
@@ -20,7 +29,7 @@ be the folder name where to install and set up your new project.
 :bulb: For more command options, refer to the documentation of the
 [`create-project`][1] command.
 
-## Recommended usage
+### Recommended usage
 
 We recommend using the command like follows:
 
@@ -40,6 +49,37 @@ This implies usage of the following options:
 
 :bulb: Tip: Add the `-v` (or `--verbose`) command option to get a verbose
 output of processing steps.
+
+## Usage with Docker
+
+### Requirements
+
+* Docker
+
+### Basic usage
+
+As an alternative to the usage with Composer, there's also a ready-to-use
+[Docker image][2]:
+
+```bash
+docker run --rm -it -v <target-dir>:/app cpsit/project-builder
+```
+
+Replace `<target-dir>` with an absolute or relative path to the directory
+where to install and set up your new project. Make sure to always mount
+the volume to `/app`.
+
+:bulb: In the entrypoint, `composer create-project` is executed. It already
+contains all [recommended command options](#recommended-usage).
+
+### Available image tags
+
+The following image tags are currently available:
+
+| Tag name    | Description                                   |
+|-------------|-----------------------------------------------|
+| `<version>` | The appropriate project version, e.g. `0.1.0` |
+| `latest`    | The latest project version                    |
 
 ## Next steps
 
@@ -69,3 +109,4 @@ after successful project creation. Those steps highly depend on the
 project type. Read more at [Processing build steps#Show next steps](processing-build-steps.md#show-next-steps).
 
 [1]: https://getcomposer.org/doc/03-cli.md#create-project
+[2]: https://hub.docker.com/r/cpsit/project-builder


### PR DESCRIPTION
With this PR, a new Docker image `cpsit/project-builder` is configured. It can be used as an alternative way to the recommended way with Composer.

Usage:

```bash
docker run --rm -it -v <target-dir>:/app cpsit/project-builder
```