### PR TITLE
[!!!][FEATURE] Allow selection of multiple sub-property options

### DIFF
--- a/resources/config.schema.json
+++ b/resources/config.schema.json
@@ -136,6 +136,11 @@
 						"$ref": "#/definitions/option"
 					}
 				},
+				"multiple": {
+					"type": "boolean",
+					"title": "Allow selection of multiple sub-property options",
+					"description": "Will only be respected for sub-property type \"select\""
+				},
 				"defaultValue": {
 					"title": "The default (fallback) value of the sub-property",
 					"oneOf": [

--- a/src/Builder/Config/ValueObject/CustomizableInterface.php
+++ b/src/Builder/Config/ValueObject/CustomizableInterface.php
@@ -40,6 +40,8 @@ interface CustomizableInterface
      */
     public function getOptions(): array;
 
+    public function canHaveMultipleValues(): bool;
+
     /**
      * @return mixed
      */

--- a/src/Builder/Config/ValueObject/SubProperty.php
+++ b/src/Builder/Config/ValueObject/SubProperty.php
@@ -43,6 +43,7 @@ final class SubProperty implements CustomizableInterface
      * @var list<PropertyOption>
      */
     private array $options;
+    private bool $multiple;
 
     /**
      * @var mixed
@@ -69,6 +70,7 @@ final class SubProperty implements CustomizableInterface
         string $if = null,
         $value = null,
         array $options = [],
+        bool $multiple = false,
         $defaultValue = null,
         array $validators = [],
         ?Property $parent = null
@@ -80,6 +82,7 @@ final class SubProperty implements CustomizableInterface
         $this->if = $if;
         $this->value = $value;
         $this->options = $options;
+        $this->multiple = $multiple;
         $this->defaultValue = $defaultValue;
         $this->validators = $validators;
         $this->parent = $parent;
@@ -103,6 +106,11 @@ final class SubProperty implements CustomizableInterface
     public function getOptions(): array
     {
         return $this->options;
+    }
+
+    public function canHaveMultipleValues(): bool
+    {
+        return $this->multiple;
     }
 
     /**

--- a/src/Builder/Generator/Step/Interaction/SelectInteraction.php
+++ b/src/Builder/Generator/Step/Interaction/SelectInteraction.php
@@ -27,7 +27,6 @@ use CPSIT\ProjectBuilder\Builder;
 use CPSIT\ProjectBuilder\IO;
 use CPSIT\ProjectBuilder\Twig;
 use Symfony\Component\ExpressionLanguage;
-use function is_bool;
 use function is_string;
 
 /**
@@ -54,15 +53,19 @@ final class SelectInteraction implements InteractionInterface
         $this->renderer = $renderer;
     }
 
+    /**
+     * @return string|list<string>|null
+     */
     public function interact(
         Builder\Config\ValueObject\CustomizableInterface $subject,
         Builder\BuildInstructions $instructions
-    ): string {
+    ) {
         return $this->reader->choices(
             $subject->getName(),
             $this->processOptions($subject->getOptions(), $instructions),
             $this->renderValue($subject->getDefaultValue(), $instructions),
-            $subject->isRequired()
+            $subject->isRequired(),
+            $subject->canHaveMultipleValues()
         );
     }
 
@@ -97,16 +100,12 @@ final class SelectInteraction implements InteractionInterface
     /**
      * @param mixed $value
      *
-     * @return ($value is string ? string : ($value is bool ? bool : null))
+     * @phpstan-return ($value is string ? string : null)
      */
-    private function renderValue($value, Builder\BuildInstructions $instructions)
+    private function renderValue($value, Builder\BuildInstructions $instructions): ?string
     {
-        if (!is_string($value) && !is_bool($value)) {
+        if (!is_string($value)) {
             return null;
-        }
-
-        if (is_bool($value)) {
-            return $value;
         }
 
         $renderer = $this->renderer->withDefaultTemplate($value);

--- a/src/IO/InputReader.php
+++ b/src/IO/InputReader.php
@@ -25,7 +25,10 @@ namespace CPSIT\ProjectBuilder\IO;
 
 use Composer\IO;
 use CPSIT\ProjectBuilder\Exception;
+use function array_filter;
 use function array_key_first;
+use function array_map;
+use function is_array;
 use function is_string;
 use function trim;
 
@@ -76,12 +79,23 @@ final class InputReader
      * @param list<string>     $choices
      * @param bool|string|null $default
      *
+     * @return string|list<string>|null
+     * @phpstan-return ($multiple is true ? list<string> : string|null)
+     *
      * @throws Exception\IOException
      */
-    public function choices(string $label, array $choices, $default = null, bool $required = false): string
-    {
+    public function choices(
+        string $label,
+        array $choices,
+        $default = null,
+        bool $required = false,
+        bool $multiple = false
+    ) {
+        $noSelectionIndex = null;
+
         if (!$required) {
             array_unshift($choices, '<info>No selection</info>');
+            $noSelectionIndex = array_key_first($choices);
         }
 
         if (null === $default) {
@@ -91,17 +105,14 @@ final class InputReader
             $default = false;
         }
 
-        $label = Messenger::decorateLabel($label, $default);
-        $answer = (int) $this->io->select($label, $choices, $default, 3);
+        $label = Messenger::decorateLabel($label, $default, $required, [], $multiple);
+        $answer = $this->io->select($label, $choices, $default, 3, 'Value "%s" is invalid', $multiple);
 
-        if (isset($choices[$answer])) {
-            return $choices[$answer];
-        }
-        if (isset($choices[$default])) {
-            return $choices[$default];
+        if (is_array($answer)) {
+            return $this->parseMultipleAnswers($answer, $choices, $noSelectionIndex);
         }
 
-        throw Exception\ValidationException::create('No selection was made. Please try again.');
+        return $this->parseSingleAnswer((int) $answer, $choices, $noSelectionIndex);
     }
 
     /**
@@ -122,6 +133,52 @@ final class InputReader
         }
 
         return $noValue;
+    }
+
+    /**
+     * @param list<string|int> $answers
+     * @param list<string>     $choices
+     *
+     * @return list<string>
+     */
+    private function parseMultipleAnswers(array $answers, array $choices, int $noSelectionIndex = null): array
+    {
+        $selections = array_map(
+            fn ($answer): string => $choices[(int) $answer],
+            array_filter($answers, fn ($answer): bool => $noSelectionIndex !== (int) $answer)
+        );
+
+        // @codeCoverageIgnoreStart
+        if ([] === $selections) {
+            throw Exception\ValidationException::create('No selection was made. Please try again.');
+        }
+        // @codeCoverageIgnoreEnd
+
+        return $selections;
+    }
+
+    /**
+     * @param list<string> $choices
+     */
+    private function parseSingleAnswer(int $answer, array $choices, int $noSelectionIndex = null): ?string
+    {
+        $selection = null;
+
+        if ($noSelectionIndex === $answer) {
+            return null;
+        }
+
+        if (isset($choices[$answer])) {
+            $selection = $choices[$answer];
+        }
+
+        // @codeCoverageIgnoreStart
+        if (null === $selection) {
+            throw Exception\ValidationException::create('No selection was made. Please try again.');
+        }
+        // @codeCoverageIgnoreEnd
+
+        return $selection;
     }
 
     private function makeValidator(

--- a/src/IO/Messenger.php
+++ b/src/IO/Messenger.php
@@ -320,13 +320,24 @@ final class Messenger
         string $label,
         $default = null,
         bool $required = true,
-        array $alternatives = []
+        array $alternatives = [],
+        bool $multiple = false
     ): string {
         $label = preg_replace('/(\s*:\s*)?$/', '', $label);
 
+        $notices = [];
+
         if (!$required) {
-            $label .= ' (<comment>optional</comment>)';
+            $notices[] = 'optional';
         }
+        if ($multiple) {
+            $notices[] = 'multiple allowed, separate by comma';
+        }
+
+        if ([] !== $notices) {
+            $label .= sprintf(' (<comment>%s</comment>)', implode('</comment>, <comment>', $notices));
+        }
+
         if ([] !== $alternatives) {
             array_unshift($alternatives, '');
         }

--- a/tests/src/Builder/Config/ConfigFactoryTest.php
+++ b/tests/src/Builder/Config/ConfigFactoryTest.php
@@ -111,6 +111,7 @@ final class ConfigFactoryTest extends TestCase
                             null,
                             null,
                             [],
+                            false,
                             null,
                             [
                                 new Src\Builder\Config\ValueObject\PropertyValidator(

--- a/tests/src/Builder/Config/ValueObject/SubPropertyTest.php
+++ b/tests/src/Builder/Config/ValueObject/SubPropertyTest.php
@@ -49,6 +49,7 @@ final class SubPropertyTest extends TestCase
             [
                 new Src\Builder\Config\ValueObject\PropertyOption('value'),
             ],
+            true,
             'defaultValue',
             [
                 new Src\Builder\Config\ValueObject\PropertyValidator('type'),
@@ -86,6 +87,14 @@ final class SubPropertyTest extends TestCase
             ],
             $this->subject->getOptions()
         );
+    }
+
+    /**
+     * @test
+     */
+    public function canHaveMultipleValuesReturnsTrue(): void
+    {
+        self::assertTrue($this->subject->canHaveMultipleValues());
     }
 
     /**

--- a/tests/src/Builder/Generator/Step/Interaction/QuestionInteractionTest.php
+++ b/tests/src/Builder/Generator/Step/Interaction/QuestionInteractionTest.php
@@ -101,6 +101,7 @@ final class QuestionInteractionTest extends Tests\ContainerAwareTestCase
             null,
             null,
             $options,
+            false,
             $defaultValue
         );
     }

--- a/tests/src/Builder/Generator/Step/Interaction/SelectInteractionTest.php
+++ b/tests/src/Builder/Generator/Step/Interaction/SelectInteractionTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/project-builder".
+ *
+ * Copyright (C) 2022 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\ProjectBuilder\Tests\Builder\Generator\Step\Interaction;
+
+use CPSIT\ProjectBuilder as Src;
+use CPSIT\ProjectBuilder\Tests;
+
+/**
+ * SelectInteractionTest.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+final class SelectInteractionTest extends Tests\ContainerAwareTestCase
+{
+    private Src\Builder\Generator\Step\Interaction\SelectInteraction $subject;
+    private Src\Builder\BuildInstructions $instructions;
+
+    protected function setUp(): void
+    {
+        $this->subject = self::$container->get(Src\Builder\Generator\Step\Interaction\SelectInteraction::class);
+        $this->instructions = new Src\Builder\BuildInstructions(self::$config, 'foo');
+    }
+
+    /**
+     * @test
+     */
+    public function interactReturnsNullOnEmptyUserInput(): void
+    {
+        $interactionSubject = $this->buildInteractionSubject();
+
+        self::assertNull($this->subject->interact($interactionSubject, $this->instructions));
+    }
+
+    /**
+     * @test
+     */
+    public function interactReturnsFirstOptionOnEmptyUserInputAndRequiredSelection(): void
+    {
+        $propertyOptions = [
+            new Src\Builder\Config\ValueObject\PropertyOption('foo'),
+            new Src\Builder\Config\ValueObject\PropertyOption('bar'),
+        ];
+        $interactionSubject = $this->buildInteractionSubject($propertyOptions, false, null, true);
+
+        self::assertSame('foo', $this->subject->interact($interactionSubject, $this->instructions));
+    }
+
+    /**
+     * @test
+     */
+    public function interactReturnsDefaultValueOnEmptyUserInputAndRequiredSelection(): void
+    {
+        $propertyOptions = [
+            new Src\Builder\Config\ValueObject\PropertyOption('foo'),
+            new Src\Builder\Config\ValueObject\PropertyOption('bar'),
+        ];
+        $interactionSubject = $this->buildInteractionSubject($propertyOptions, false, 'bar', true);
+
+        self::assertSame('bar', $this->subject->interact($interactionSubject, $this->instructions));
+    }
+
+    /**
+     * @test
+     */
+    public function interactReturnsSelectedOption(): void
+    {
+        $propertyOptions = [
+            new Src\Builder\Config\ValueObject\PropertyOption('foo'),
+            new Src\Builder\Config\ValueObject\PropertyOption('bar'),
+        ];
+        $interactionSubject = $this->buildInteractionSubject($propertyOptions, false, null, true);
+
+        self::$io->setUserInputs(['bar']);
+
+        self::assertSame('bar', $this->subject->interact($interactionSubject, $this->instructions));
+    }
+
+    /**
+     * @test
+     */
+    public function interactReturnsSelectedOptionsIfMultipleOptionsAreAllowed(): void
+    {
+        $propertyOptions = [
+            new Src\Builder\Config\ValueObject\PropertyOption('foo'),
+            new Src\Builder\Config\ValueObject\PropertyOption('bar'),
+            new Src\Builder\Config\ValueObject\PropertyOption('hello'),
+            new Src\Builder\Config\ValueObject\PropertyOption('world'),
+        ];
+        $interactionSubject = $this->buildInteractionSubject($propertyOptions, true);
+
+        self::$io->setUserInputs(['hello,bar']);
+
+        self::assertSame(['bar', 'hello'], $this->subject->interact($interactionSubject, $this->instructions));
+    }
+
+    /**
+     * @param list<Src\Builder\Config\ValueObject\PropertyOption> $options
+     * @param mixed                                               $defaultValue
+     */
+    private function buildInteractionSubject(
+        array $options = [],
+        bool $multiple = false,
+        $defaultValue = null,
+        bool $required = false
+    ): Src\Builder\Config\ValueObject\CustomizableInterface {
+        $validators = [];
+
+        if ($required) {
+            $validators[] = new Src\Builder\Config\ValueObject\PropertyValidator('notEmpty');
+        }
+
+        return new Src\Builder\Config\ValueObject\SubProperty(
+            'foo',
+            'foo',
+            'foo',
+            null,
+            null,
+            null,
+            $options,
+            $multiple,
+            $defaultValue,
+            $validators
+        );
+    }
+}


### PR DESCRIPTION
With this PR, a new config property `properties.*.properties.*.multiple` is introduced. It allows selection of multiple sub-property options.

Example:

```diff
 properties:
   - identifier: foo
     name: Foo
     properties:
       - identifier: bar
         name: Bar
         options:
           - value: optionA
           - value: optionB
           - value: optionC
           - value: optionD
+        multiple: true
```