### PR TITLE
[!!!][BUGFIX] Require cuyz/valinor ^0.12.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		"composer-runtime-api": "^2.1",
 		"cocur/slugify": "^4.1",
 		"composer/installers": "^2.0",
-		"cuyz/valinor": "^0.10.0 || ^0.11.0",
+		"cuyz/valinor": "^0.12.0",
 		"guzzlehttp/guzzle": "^7.0",
 		"nyholm/psr7": "^1.5",
 		"oomphinc/composer-installers-extender": "^2.0",

--- a/src/Builder/Config/ValueObject/PropertyOption.php
+++ b/src/Builder/Config/ValueObject/PropertyOption.php
@@ -35,17 +35,23 @@ final class PropertyOption
     use ValueTrait;
 
     /**
-     * @var string
+     * @var int|float|string
      */
     protected $value;
 
-    public function __construct(string $value, string $if = null)
+    /**
+     * @param int|float|string $value
+     */
+    public function __construct($value, string $if = null)
     {
         $this->value = $value;
         $this->if = $if;
     }
 
-    public function getValue(): string
+    /**
+     * @return int|float|string
+     */
+    public function getValue()
     {
         return $this->value;
     }

--- a/src/Builder/Generator/Step/CollectBuildInstructionsStep.php
+++ b/src/Builder/Generator/Step/CollectBuildInstructionsStep.php
@@ -141,7 +141,7 @@ final class CollectBuildInstructionsStep extends AbstractStep
     /**
      * @param list<Builder\Config\ValueObject\PropertyOption> $options
      *
-     * @return mixed
+     * @return int|float|string|null
      */
     private function processOptions(array $options, Builder\BuildInstructions $instructions)
     {

--- a/src/Builder/Generator/Step/Interaction/QuestionInteraction.php
+++ b/src/Builder/Generator/Step/Interaction/QuestionInteraction.php
@@ -94,7 +94,7 @@ final class QuestionInteraction implements InteractionInterface
         );
 
         foreach ($options as $option) {
-            $value = $this->renderValue($option->getValue(), $instructions);
+            $value = $this->renderValue((string) $option->getValue(), $instructions);
             $condition = $option->getCondition();
 
             if (!$option->hasCondition()) {

--- a/src/Builder/Generator/Step/Interaction/SelectInteraction.php
+++ b/src/Builder/Generator/Step/Interaction/SelectInteraction.php
@@ -28,6 +28,7 @@ use CPSIT\ProjectBuilder\IO;
 use CPSIT\ProjectBuilder\Twig;
 use Symfony\Component\ExpressionLanguage;
 
+use function array_filter;
 use function is_string;
 
 /**
@@ -91,15 +92,15 @@ final class SelectInteraction implements InteractionInterface
 
         foreach ($options as $option) {
             if ($option->conditionMatches($this->expressionLanguage, $instructions->getTemplateVariables(), true)) {
-                $processedOptions[] = $this->renderValue($option->getValue(), $instructions);
+                $processedOptions[] = $this->renderValue((string) $option->getValue(), $instructions);
             }
         }
 
-        return $processedOptions;
+        return array_filter($processedOptions);
     }
 
     /**
-     * @param mixed $value
+     * @param int|float|string|bool|null $value
      *
      * @phpstan-return ($value is string ? string : null)
      */


### PR DESCRIPTION
Because of https://github.com/advisories/GHSA-5pgm-3j3g-2rc7, the library `cuyz/valinor` is now required in a minimum version of `0.12.0`. With this dependency update, an additional bug concerning supported types in property options is fixed.