### PR TITLE
[FEATURE] Add support for cuyz/valinor ^0.13.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		"composer-runtime-api": "^2.1",
 		"cocur/slugify": "^4.1",
 		"composer/installers": "^2.0",
-		"cuyz/valinor": "^0.12.0",
+		"cuyz/valinor": "^0.12.0 || ^0.13.0",
 		"guzzlehttp/guzzle": "^7.0",
 		"nyholm/psr7": "^1.5",
 		"oomphinc/composer-installers-extender": "^2.0",

--- a/tests/src/Error/ErrorHandlerTest.php
+++ b/tests/src/Error/ErrorHandlerTest.php
@@ -134,8 +134,9 @@ final class ErrorHandlerTest extends Tests\ContainerAwareTestCase
             yield 'MappingError' => [
                 $error,
                 [
-                    'Could not map type `array{foo: string}` with the given source. [1617193185]',
-                    '- Cannot be empty and must be filled with a value matching type `array{foo: string}`.',
+                    'Could not map type `array{foo: string}`',
+                    '[1617193185]',
+                    'Cannot be empty and must be filled with a value matching type `array{foo: string}`.',
                 ],
             ];
         }


### PR DESCRIPTION
This PR adds support for recently published version `0.13.0` of `cuyz/valinor` and following patch releases.