### PR TITLE
[TASK] Include Composer 2.4 in test matrix

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         php-version: ["7.4", "8.0", "8.1"]
-        composer-version: ["2.1", "2.2", "2.3"]
+        composer-version: ["2.1", "2.2", "2.3", "2.4"]
         preferred-install: ["stable", "lowest"]
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This PR enables tests for the upcoming `2.4` release of Composer in the test matrix.