### PR TITLE
[TASK] Enable Dependabot updates for Composer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,15 @@ updates:
     labels:
       - dependencies
     open-pull-requests-limit: 10
+
+  - package-ecosystem: composer
+    directory: '/'
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: '[TASK]'
+    target-branch: develop
+    labels:
+      - dependencies
+    open-pull-requests-limit: 10
+    versioning-strategy: widen


### PR DESCRIPTION
This PR adds additional support for Composer updates managed by Dependabot.