### PR TITLE
[!!!][FEATURE] Deprecate config identifier and use Composer name instead

### DIFF
--- a/resources/config.schema.json
+++ b/resources/config.schema.json
@@ -6,7 +6,8 @@
 		"identifier": {
 			"type": "string",
 			"title": "Project template identifier",
-			"description": "Will be used to locate source and configuration files"
+			"description": "No longer needed, templates are now identified by their Composer package name.",
+			"deprecated": true
 		},
 		"name": {
 			"type": "string",
@@ -33,7 +34,6 @@
 	},
 	"additionalProperties": false,
 	"required": [
-		"identifier",
 		"name",
 		"steps"
 	],

--- a/src/Builder/Config/ConfigFactory.php
+++ b/src/Builder/Config/ConfigFactory.php
@@ -35,7 +35,6 @@ use Symfony\Component\Filesystem;
 use Symfony\Component\Yaml;
 
 use function dirname;
-use function is_iterable;
 use function json_decode;
 
 /**
@@ -73,7 +72,7 @@ final class ConfigFactory
         return new self($mapper, new JsonSchema\Validator());
     }
 
-    public function buildFromFile(string $file): Config
+    public function buildFromFile(string $file, string $identifier): Config
     {
         $type = $this->determineFileType($file);
         $content = file_get_contents($file);
@@ -84,13 +83,12 @@ final class ConfigFactory
             // @codeCoverageIgnoreEnd
         }
 
-        $config = $this->buildFromString($content, $type);
-        $config->setDeclaringFile($file);
+        $config = $this->buildFromString($content, $identifier, $type);
 
-        return $config;
+        return $config->setDeclaringFile($file);
     }
 
-    public function buildFromString(string $content, string $type): Config
+    public function buildFromString(string $content, string $identifier, string $type): Config
     {
         $parsedContent = $this->parseContent($content, $type);
         $validationResult = $this->validateConfig($parsedContent);
@@ -99,7 +97,7 @@ final class ConfigFactory
             throw Exception\InvalidConfigurationException::forValidationErrors($validationResult->error());
         }
 
-        $source = $this->generateMapperSource($content, $type);
+        $source = $this->generateMapperSource($content, $identifier, $type);
 
         return $this->mapper->map(Config::class, $source);
     }
@@ -122,16 +120,16 @@ final class ConfigFactory
         return $this->validator->validate($parsedContent, $schemaReference);
     }
 
-    private function generateMapperSource(string $content, string $type): Mapper\Source\Source
+    private function generateMapperSource(string $content, string $identifier, string $type): Mapper\Source\Source
     {
         switch ($type) {
             case FileType::YAML:
-                $iterable = Yaml\Yaml::parse($content);
+                $parsedContent = Yaml\Yaml::parse($content);
 
                 break;
 
             case FileType::JSON:
-                $iterable = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
+                $parsedContent = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
 
                 break;
 
@@ -140,12 +138,15 @@ final class ConfigFactory
         }
 
         // @codeCoverageIgnoreStart
-        if (!is_iterable($iterable)) {
+        if (!is_array($parsedContent)) {
             throw Exception\InvalidConfigurationException::forSource($content);
         }
         // @codeCoverageIgnoreEnd
 
-        return Mapper\Source\Source::iterable($iterable);
+        // Enforce custom identifier
+        $parsedContent['identifier'] = $identifier;
+
+        return Mapper\Source\Source::array($parsedContent);
     }
 
     private function parseContent(string $content, string $type): stdClass

--- a/src/Exception/InvalidConfigurationException.php
+++ b/src/Exception/InvalidConfigurationException.php
@@ -106,4 +106,12 @@ final class InvalidConfigurationException extends Exception
             1653424186
         );
     }
+
+    public static function forMissingManifestFile(string $file): self
+    {
+        return new self(
+            sprintf('The Composer manifest file for "%s" could not be found.', $file),
+            1664558700
+        );
+    }
 }

--- a/src/Resource/Local/Composer.php
+++ b/src/Resource/Local/Composer.php
@@ -129,10 +129,13 @@ final class Composer
     /**
      * @internal
      */
-    private static function createComposer(string $rootPath): \Composer\Composer
+    public static function createComposer(string $rootPath): \Composer\Composer
     {
         $factory = new Factory();
 
-        return $factory->createComposer(new IO\NullIO(), null, false, $rootPath);
+        return $factory->createComposer(
+            new IO\NullIO(),
+            Filesystem\Path::join($rootPath, 'composer.json')
+        );
     }
 }

--- a/tests/src/Builder/Config/ConfigFactoryTest.php
+++ b/tests/src/Builder/Config/ConfigFactoryTest.php
@@ -53,7 +53,7 @@ final class ConfigFactoryTest extends TestCase
         $this->expectExceptionCode(1652800199);
         $this->expectExceptionMessage('The type "php" is not supported.');
 
-        $this->subject->buildFromFile(__FILE__);
+        $this->subject->buildFromFile(__FILE__, 'foo');
     }
 
     /**
@@ -64,7 +64,7 @@ final class ConfigFactoryTest extends TestCase
         $this->expectException(Src\Exception\InvalidConfigurationException::class);
         $this->expectExceptionCode(1653303396);
 
-        $this->subject->buildFromFile(dirname(__DIR__, 2).'/Fixtures/Files/invalid-config.yaml');
+        $this->subject->buildFromFile(dirname(__DIR__, 2).'/Fixtures/Files/invalid-config.yaml', 'foo');
     }
 
     /**
@@ -125,7 +125,7 @@ final class ConfigFactoryTest extends TestCase
                         ),
                     ],
                 ),
-            ],
+            ]
         );
 
         foreach (['json', 'yaml'] as $fileType) {
@@ -133,7 +133,7 @@ final class ConfigFactoryTest extends TestCase
             $expected = $createConfig($fileType);
             $expected->setDeclaringFile($configFile);
 
-            self::assertEquals($expected, $this->subject->buildFromFile($configFile));
+            self::assertEquals($expected, $this->subject->buildFromFile($configFile, $fileType));
         }
     }
 
@@ -146,7 +146,7 @@ final class ConfigFactoryTest extends TestCase
         $this->expectExceptionCode(1652800199);
         $this->expectExceptionMessage('The type "php" is not supported.');
 
-        $this->subject->buildFromString('foo', 'php');
+        $this->subject->buildFromString('foo', 'baz', 'php');
     }
 
     /**
@@ -158,6 +158,6 @@ final class ConfigFactoryTest extends TestCase
         $this->expectExceptionCode(1653058480);
         $this->expectExceptionMessage('The config source "foo" is invalid and cannot be processed.');
 
-        $this->subject->buildFromString('foo', 'yaml');
+        $this->subject->buildFromString('foo', 'baz', 'yaml');
     }
 }

--- a/tests/src/Builder/Config/ConfigReaderTest.php
+++ b/tests/src/Builder/Config/ConfigReaderTest.php
@@ -68,9 +68,9 @@ final class ConfigReaderTest extends TestCase
 
         $this->expectException(Src\Exception\InvalidConfigurationException::class);
         $this->expectExceptionCode(1652950002);
-        $this->expectExceptionMessageMatches('#^Configuration for "invalid" already exists as "[^"]+"\\. Please use only one config file per template!$#');
+        $this->expectExceptionMessageMatches('#^Configuration for "cpsit/project-builder-template-invalid" already exists as "[^"]+"\\. Please use only one config file per template!$#');
 
-        $subject->readConfig('invalid');
+        $subject->readConfig('cpsit/project-builder-template-invalid');
     }
 
     /**
@@ -78,9 +78,9 @@ final class ConfigReaderTest extends TestCase
      */
     public function readConfigReturnsHydratedConfigObject(): void
     {
-        $actual = $this->subject->readConfig('yaml');
+        $actual = $this->subject->readConfig('cpsit/project-builder-template-yaml');
 
-        self::assertSame('yaml', $actual->getIdentifier());
+        self::assertSame('cpsit/project-builder-template-yaml', $actual->getIdentifier());
         self::assertSame(
             dirname(__DIR__, 2).'/Fixtures/Templates/yaml-template/config.yaml',
             $actual->getDeclaringFile()
@@ -92,8 +92,8 @@ final class ConfigReaderTest extends TestCase
      */
     public function hasConfigChecksWhetherConfigWithGivenIdentifierExists(): void
     {
-        self::assertTrue($this->subject->hasConfig('json'));
-        self::assertTrue($this->subject->hasConfig('yaml'));
+        self::assertTrue($this->subject->hasConfig('cpsit/project-builder-template-json'));
+        self::assertTrue($this->subject->hasConfig('cpsit/project-builder-template-yaml'));
         self::assertFalse($this->subject->hasConfig('foo'));
     }
 
@@ -103,8 +103,8 @@ final class ConfigReaderTest extends TestCase
     public function listTemplateListsAllAvailableTemplates(): void
     {
         $expected = [
-            'json' => 'Json',
-            'yaml' => 'Yaml',
+            'cpsit/project-builder-template-json' => 'Json',
+            'cpsit/project-builder-template-yaml' => 'Yaml',
         ];
 
         self::assertSame($expected, $this->subject->listTemplates());

--- a/tests/src/Builder/Generator/GeneratorTest.php
+++ b/tests/src/Builder/Generator/GeneratorTest.php
@@ -149,7 +149,8 @@ final class GeneratorTest extends Tests\ContainerAwareTestCase
         $configReader = Src\Builder\Config\ConfigFactory::create();
 
         return $configReader->buildFromFile(
-            dirname(__DIR__, 2).'/Fixtures/Templates/yaml-template/config.yaml'
+            dirname(__DIR__, 2).'/Fixtures/Templates/yaml-template/config.yaml',
+            'yaml'
         );
     }
 

--- a/tests/src/Builder/Generator/Step/InstallComposerDependenciesStepTest.php
+++ b/tests/src/Builder/Generator/Step/InstallComposerDependenciesStepTest.php
@@ -97,7 +97,7 @@ final class InstallComposerDependenciesStepTest extends Tests\ContainerAwareTest
 
         $configFactory = Src\Builder\Config\ConfigFactory::create();
 
-        return $configFactory->buildFromFile(self::$temporaryDirectory.'/config.yaml');
+        return $configFactory->buildFromFile(self::$temporaryDirectory.'/config.yaml', 'yaml');
     }
 
     protected function tearDown(): void

--- a/tests/src/Builder/Generator/Step/ProcessSharedSourceFilesStepTest.php
+++ b/tests/src/Builder/Generator/Step/ProcessSharedSourceFilesStepTest.php
@@ -80,7 +80,10 @@ final class ProcessSharedSourceFilesStepTest extends Tests\ContainerAwareTestCas
     {
         $configFactory = Src\Builder\Config\ConfigFactory::create();
 
-        return $configFactory->buildFromFile(dirname(__DIR__, 3).'/Fixtures/Templates/yaml-template/config.yaml');
+        return $configFactory->buildFromFile(
+            dirname(__DIR__, 3).'/Fixtures/Templates/yaml-template/config.yaml',
+            'yaml'
+        );
     }
 
     private function findStep(): Src\Builder\Config\ValueObject\Step

--- a/tests/src/Builder/Generator/Step/ProcessSourceFilesStepTest.php
+++ b/tests/src/Builder/Generator/Step/ProcessSourceFilesStepTest.php
@@ -80,7 +80,10 @@ final class ProcessSourceFilesStepTest extends Tests\ContainerAwareTestCase
     {
         $configFactory = Src\Builder\Config\ConfigFactory::create();
 
-        return $configFactory->buildFromFile(dirname(__DIR__, 3).'/Fixtures/Templates/yaml-template/config.yaml');
+        return $configFactory->buildFromFile(
+            dirname(__DIR__, 3).'/Fixtures/Templates/yaml-template/config.yaml',
+            'yaml'
+        );
     }
 
     private function findStep(): Src\Builder\Config\ValueObject\Step

--- a/tests/src/ContainerAwareTestCase.php
+++ b/tests/src/ContainerAwareTestCase.php
@@ -82,7 +82,7 @@ abstract class ContainerAwareTestCase extends TestCase
                         ),
                     ],
                 ),
-            ],
+            ]
         );
         $config->setDeclaringFile(__FILE__);
 

--- a/tests/src/Fixtures/Files/config.json
+++ b/tests/src/Fixtures/Files/config.json
@@ -1,5 +1,4 @@
 {
-	"identifier": "dummy",
 	"name": "Dummy",
 	"steps": [
 		{

--- a/tests/src/Fixtures/Files/invalid-template/composer.json
+++ b/tests/src/Fixtures/Files/invalid-template/composer.json
@@ -1,0 +1,4 @@
+{
+	"name": "cpsit/project-builder-template-invalid",
+	"type": "project-builder-template"
+}

--- a/tests/src/Fixtures/Files/invalid-template/config.json
+++ b/tests/src/Fixtures/Files/invalid-template/config.json
@@ -1,5 +1,4 @@
 {
-	"identifier": "invalid",
 	"name": "Invalid",
 	"steps": [
 		{

--- a/tests/src/Fixtures/Files/invalid-template/config.yaml
+++ b/tests/src/Fixtures/Files/invalid-template/config.yaml
@@ -1,4 +1,3 @@
-identifier: invalid
 name: Invalid
 
 steps:

--- a/tests/src/Fixtures/Templates/json-template/config.json
+++ b/tests/src/Fixtures/Templates/json-template/config.json
@@ -1,5 +1,4 @@
 {
-	"identifier": "json",
 	"name": "Json",
 	"steps": [
 		{

--- a/tests/src/Fixtures/Templates/yaml-template/config.yaml
+++ b/tests/src/Fixtures/Templates/yaml-template/config.yaml
@@ -1,4 +1,3 @@
-identifier: yaml
 name: Yaml
 
 steps:


### PR DESCRIPTION
With this PR, the Composer package name of a project builder template repository is now used as identifier. The `identifier` property provided with the template configuration is now deprecated and will no longer be respected.