### PR TITLE
[FEATURE] Support `fnmatch` symbols in step's file condition paths

### DIFF
--- a/resources/config.schema.json
+++ b/resources/config.schema.json
@@ -285,7 +285,7 @@
 				},
 				"path": {
 					"type": "string",
-					"title": "Relative path to a file"
+					"title": "Relative path to a file, can contain symbols processable by `fnmatch`"
 				}
 			},
 			"additionalProperties": false,

--- a/src/Builder/Generator/Step/ProcessingFilesTrait.php
+++ b/src/Builder/Generator/Step/ProcessingFilesTrait.php
@@ -65,7 +65,7 @@ trait ProcessingFilesTrait
     protected function shouldProcessFile(Finder\SplFileInfo $file, Builder\BuildInstructions $instructions): bool
     {
         foreach ($this->config->getOptions()->getFileConditions() as $fileCondition) {
-            if ($file->getRelativePathname() !== $fileCondition->getPath()) {
+            if (!fnmatch($fileCondition->getPath(), $file->getRelativePathname())) {
                 continue;
             }
 

--- a/tests/src/Builder/Config/ConfigFactoryTest.php
+++ b/tests/src/Builder/Config/ConfigFactoryTest.php
@@ -81,12 +81,14 @@ final class ConfigFactoryTest extends TestCase
                     'processSourceFiles',
                     new Src\Builder\Config\ValueObject\StepOptions([
                         new Src\Builder\Config\ValueObject\FileCondition('dummy-2.'.$type, 'false'),
+                        new Src\Builder\Config\ValueObject\FileCondition('*-3.'.$type, 'false'),
                     ])
                 ),
                 new Src\Builder\Config\ValueObject\Step(
                     'processSharedSourceFiles',
                     new Src\Builder\Config\ValueObject\StepOptions([
                         new Src\Builder\Config\ValueObject\FileCondition('shared-dummy-2.'.$type, 'false'),
+                        new Src\Builder\Config\ValueObject\FileCondition('shared-*-3.'.$type, 'false'),
                     ])
                 ),
                 new Src\Builder\Config\ValueObject\Step('mirrorProcessedFiles'),

--- a/tests/src/Builder/Generator/Step/ProcessSharedSourceFilesStepTest.php
+++ b/tests/src/Builder/Generator/Step/ProcessSharedSourceFilesStepTest.php
@@ -59,6 +59,8 @@ final class ProcessSharedSourceFilesStepTest extends Tests\ContainerAwareTestCas
         self::assertCount(1, $this->subject->getProcessedFiles());
         self::assertSame('shared-dummy.yaml', $this->subject->getProcessedFiles()[0]->getTargetFile()->getRelativePathname());
         self::assertFileExists($this->result->getInstructions()->getTemporaryDirectory().'/shared-dummy.yaml');
+        self::assertFileDoesNotExist($this->result->getInstructions()->getTemporaryDirectory().'/shared-dummy-2.yaml');
+        self::assertFileDoesNotExist($this->result->getInstructions()->getTemporaryDirectory().'/shared-dummy-3.yaml');
         self::assertTrue($this->result->isStepApplied($this->subject));
     }
 

--- a/tests/src/Builder/Generator/Step/ProcessSourceFilesStepTest.php
+++ b/tests/src/Builder/Generator/Step/ProcessSourceFilesStepTest.php
@@ -59,6 +59,8 @@ final class ProcessSourceFilesStepTest extends Tests\ContainerAwareTestCase
         self::assertCount(1, $this->subject->getProcessedFiles());
         self::assertSame('dummy.yaml', $this->subject->getProcessedFiles()[0]->getTargetFile()->getRelativePathname());
         self::assertFileExists($this->result->getInstructions()->getTemporaryDirectory().'/dummy.yaml');
+        self::assertFileDoesNotExist($this->result->getInstructions()->getTemporaryDirectory().'/dummy-2.yaml');
+        self::assertFileDoesNotExist($this->result->getInstructions()->getTemporaryDirectory().'/dummy-3.yaml');
         self::assertTrue($this->result->isStepApplied($this->subject));
     }
 

--- a/tests/src/Fixtures/Templates/json-template/config.json
+++ b/tests/src/Fixtures/Templates/json-template/config.json
@@ -11,6 +11,10 @@
 					{
 						"path": "dummy-2.json",
 						"if": "false"
+					},
+					{
+						"path": "*-3.json",
+						"if": "false"
 					}
 				]
 			}
@@ -21,6 +25,10 @@
 				"fileConditions": [
 					{
 						"path": "shared-dummy-2.json",
+						"if": "false"
+					},
+					{
+						"path": "shared-*-3.json",
 						"if": "false"
 					}
 				]

--- a/tests/src/Fixtures/Templates/json-template/templates/shared/shared-dummy-3.yaml
+++ b/tests/src/Fixtures/Templates/json-template/templates/shared/shared-dummy-3.yaml
@@ -1,0 +1,1 @@
+hello: world

--- a/tests/src/Fixtures/Templates/json-template/templates/src/dummy-3.json
+++ b/tests/src/Fixtures/Templates/json-template/templates/src/dummy-3.json
@@ -1,0 +1,3 @@
+{
+	"hello": "world"
+}

--- a/tests/src/Fixtures/Templates/yaml-template/config.yaml
+++ b/tests/src/Fixtures/Templates/yaml-template/config.yaml
@@ -7,10 +7,14 @@ steps:
       fileConditions:
         - path: dummy-2.yaml
           if: 'false'
+        - path: '*-3.yaml'
+          if: 'false'
   - type: processSharedSourceFiles
     options:
       fileConditions:
         - path: shared-dummy-2.yaml
+          if: 'false'
+        - path: 'shared-*-3.yaml'
           if: 'false'
   - type: mirrorProcessedFiles
 

--- a/tests/src/Fixtures/Templates/yaml-template/templates/shared/shared-dummy-3.yaml
+++ b/tests/src/Fixtures/Templates/yaml-template/templates/shared/shared-dummy-3.yaml
@@ -1,0 +1,1 @@
+hello: world

--- a/tests/src/Fixtures/Templates/yaml-template/templates/src/dummy-3.yaml
+++ b/tests/src/Fixtures/Templates/yaml-template/templates/src/dummy-3.yaml
@@ -1,0 +1,1 @@
+hello: world


### PR DESCRIPTION
With this PR, paths in file conditions of configured steps are now tested against `fnmatch`. This allows to include supported symbols such as `*` or `.`.