### PR TITLE
[TASK] Switch to `ncipollo/release-action` for new releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,6 @@ jobs:
 
       # Create release
       - name: Create release
-        uses: softprops/action-gh-release@v1
+        uses: ncipollo/release-action@v1
         with:
-          generate_release_notes: true
+          generateReleaseNotes: true


### PR DESCRIPTION
The previously used action `softprops/action-gh-release` was not properly updated anymore. Thus, we now switch to the actively maintained action `ncipollo/release-action`.