### PR TITLE
[FEATURE] Add support for conditional properties

### DIFF
--- a/resources/config.schema.json
+++ b/resources/config.schema.json
@@ -57,6 +57,9 @@
 						},
 						"path": {
 							"$ref": "#/definitions/path"
+						},
+						"if": {
+							"$ref": "#/definitions/condition"
 						}
 					},
 					"required": [

--- a/src/Builder/Config/ValueObject/Property.php
+++ b/src/Builder/Config/ValueObject/Property.php
@@ -31,6 +31,7 @@ namespace CPSIT\ProjectBuilder\Builder\Config\ValueObject;
  */
 final class Property
 {
+    use ConditionTrait;
     use IdentifierTrait;
     use NameTrait;
     use ValueTrait;
@@ -48,12 +49,14 @@ final class Property
         string $identifier,
         string $name,
         string $path = null,
+        string $if = null,
         $value = null,
         array $properties = []
     ) {
         $this->identifier = $identifier;
         $this->name = $name;
         $this->path = $path;
+        $this->if = $if;
         $this->value = $value;
         $this->properties = $properties;
     }

--- a/src/Builder/Generator/Step/CollectBuildInstructionsStep.php
+++ b/src/Builder/Generator/Step/CollectBuildInstructionsStep.php
@@ -58,6 +58,10 @@ final class CollectBuildInstructionsStep extends AbstractStep
         $instructions = $buildResult->getInstructions();
 
         foreach ($instructions->getConfig()->getProperties() as $property) {
+            if (!$property->conditionMatches($this->expressionLanguage, $instructions->getTemplateVariables(), true)) {
+                continue;
+            }
+
             $this->messenger->section($property->getName());
 
             if ($property->hasValue() && $property->hasSubProperties()) {

--- a/tests/src/Builder/Config/ConfigFactoryTest.php
+++ b/tests/src/Builder/Config/ConfigFactoryTest.php
@@ -98,11 +98,13 @@ final class ConfigFactoryTest extends TestCase
                     'foo',
                     'Foo',
                     null,
+                    'false',
                     'foo'
                 ),
                 new Src\Builder\Config\ValueObject\Property(
                     'bar',
                     'Bar',
+                    null,
                     null,
                     null,
                     [

--- a/tests/src/Builder/Config/ValueObject/PropertyTest.php
+++ b/tests/src/Builder/Config/ValueObject/PropertyTest.php
@@ -42,6 +42,7 @@ final class PropertyTest extends TestCase
             'identifier',
             'name',
             'path',
+            'if',
             'value',
             [
                 new Src\Builder\Config\ValueObject\SubProperty(

--- a/tests/src/ContainerAwareTestCase.php
+++ b/tests/src/ContainerAwareTestCase.php
@@ -74,6 +74,7 @@ abstract class ContainerAwareTestCase extends TestCase
                     'Foo',
                     null,
                     null,
+                    null,
                     [
                         new Src\Builder\Config\ValueObject\SubProperty(
                             'bar',

--- a/tests/src/Fixtures/Templates/json-template/config.json
+++ b/tests/src/Fixtures/Templates/json-template/config.json
@@ -42,7 +42,8 @@
 		{
 			"identifier": "foo",
 			"name": "Foo",
-			"value": "foo"
+			"value": "foo",
+			"if": "false"
 		},
 		{
 			"identifier": "bar",

--- a/tests/src/Fixtures/Templates/yaml-template/config.yaml
+++ b/tests/src/Fixtures/Templates/yaml-template/config.yaml
@@ -22,6 +22,7 @@ properties:
   - identifier: foo
     name: Foo
     value: foo
+    if: 'false'
   - identifier: bar
     name: Bar
     properties:


### PR DESCRIPTION
With this PR, first-level configuration properties can now be conditional. That means, whole sections can be left out when collecting build instructions, based on the given condition.

For example, the following configuration leaves out the second section in case the sub-property of the first section is answered with "yes":

```diff
{
    // ...
    "properties": [
        {
            "identifier": "first",
            "name": "First section",
            "properties": [
                {
                    "identifier": "continue",
                    "name": "Continue with second section?",
                    "type": "question"
                }
            ]
        },
        {
            "identifier": "second",
            "name": "Second question",
+           "if": "first['continue']",
            "properties": [
                {
                    "identifier": "done",
                    "name": "Well done!",
                    "type": "staticValue",
                    "defaultValue": "Hello world"
                }
            ]
        }
    ]
}
```