### PR TITLE
[TASK] Use PHPStan extension installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
 		"donatj/mock-webserver": "^2.5",
 		"ergebnis/composer-normalize": "^2.26",
 		"friendsofphp/php-cs-fixer": "^3.8",
+		"phpstan/extension-installer": "^1.2",
 		"phpstan/phpstan": "^1.9",
 		"phpstan/phpstan-phpunit": "^1.1",
 		"phpstan/phpstan-strict-rules": "^1.2",
@@ -68,7 +69,8 @@
 	},
 	"config": {
 		"allow-plugins": {
-			"ergebnis/composer-normalize": true
+			"ergebnis/composer-normalize": true,
+			"phpstan/extension-installer": true
 		},
 		"sort-packages": true,
 		"vendor-dir": ".build/vendor"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b1e582b3860fe383379e817521030a4d",
+    "content-hash": "dcd31ae0629c21ecbd6a0de44ea6a294",
     "packages": [
         {
             "name": "cocur/slugify",
@@ -4757,6 +4757,50 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpstan/extension-installer",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/extension-installer.git",
+                "reference": "f06dbb052ddc394e7896fcd1cfcd533f9f6ace40"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/extension-installer/zipball/f06dbb052ddc394e7896fcd1cfcd533f9f6ace40",
+                "reference": "f06dbb052ddc394e7896fcd1cfcd533f9f6ace40",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.8.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "phpstan/phpstan-strict-rules": "^0.11 || ^0.12 || ^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPStan\\ExtensionInstaller\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\ExtensionInstaller\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Composer plugin for automatic installation of PHPStan extensions",
+            "support": {
+                "issues": "https://github.com/phpstan/extension-installer/issues",
+                "source": "https://github.com/phpstan/extension-installer/tree/1.2.0"
+            },
+            "time": "2022-10-17T12:59:16+00:00"
         },
         {
             "name": "phpstan/phpstan",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,9 +1,5 @@
 includes:
     - .build/vendor/phpstan/phpstan/conf/bleedingEdge.neon
-    - .build/vendor/phpstan/phpstan-phpunit/extension.neon
-    - .build/vendor/phpstan/phpstan-strict-rules/rules.neon
-    - .build/vendor/phpstan/phpstan-symfony/extension.neon
-    - .build/vendor/phpstan/phpstan-webmozart-assert/extension.neon
 parameters:
     level: max
     paths:

--- a/src/Resource/Local/Composer.php
+++ b/src/Resource/Local/Composer.php
@@ -39,7 +39,6 @@ use function basename;
 use function dirname;
 use function getenv;
 use function in_array;
-use function is_string;
 use function putenv;
 
 /**
@@ -119,9 +118,6 @@ final class Composer
 
         // Fetch vendor directory
         $vendorDir = $composer->getConfig()->get('vendor-dir');
-        if (!is_string($vendorDir)) {
-            $vendorDir = null;
-        }
 
         return $autoloadGenerator->createLoader($autoloads, $vendorDir);
     }

--- a/tests/src/Twig/Func/PhpVersionFunctionTest.php
+++ b/tests/src/Twig/Func/PhpVersionFunctionTest.php
@@ -61,21 +61,21 @@ final class PhpVersionFunctionTest extends Tests\ContainerAwareTestCase
         self::$mockHandler->append(self::createJsonResponse(['version' => '8.0.10']));
         self::$mockHandler->append(self::createJsonResponse(['version' => '8.1.4']));
 
-        self::assertSame(2, self::$mockHandler->count());
+        self::assertCount(2, self::$mockHandler);
 
         $actual = ($this->subject)('8.0');
 
         self::assertSame('8.0.10', $actual);
-        self::assertSame(1, self::$mockHandler->count());
+        self::assertCount(1, self::$mockHandler);
 
         $actual = ($this->subject)('8.0');
 
         self::assertSame('8.0.10', $actual);
-        self::assertSame(1, self::$mockHandler->count());
+        self::assertCount(1, self::$mockHandler);
 
         $actual = ($this->subject)('8.1');
 
         self::assertSame('8.1.4', $actual);
-        self::assertSame(0, self::$mockHandler->count());
+        self::assertCount(0, self::$mockHandler);
     }
 }


### PR DESCRIPTION
With this PR, we now use the PHPStan extension installer to ease integration of third-party PHPStan extensions.