### PR TITLE
[!!!][FEATURE] Drop support for PHP 7.4

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ["7.4", "8.0", "8.1"]
+        php-version: ["8.0", "8.1"]
         composer-version: ["2.1", "2.2", "2.3", "2.4"]
         dependencies: ["highest", "lowest"]
     steps:

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -38,6 +38,14 @@ $config
                 'function',
             ],
         ],
+        'trailing_comma_in_multiline' => [
+            'elements' => [
+                'arguments',
+                'arrays',
+                'match',
+                'parameters',
+            ],
+        ],
     ])
 ;
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ all steps below.
 ## Requirements
 
 - Composer >= 2.1
-- PHP >= 7.4
+- PHP >= 8.0
 
 ## Preparation
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 		}
 	],
 	"require": {
-		"php": ">= 7.4 < 8.2",
+		"php": "~8.0.0 || ~8.1.0",
 		"ext-filter": "*",
 		"ext-json": "*",
 		"ext-mbstring": "*",
@@ -33,7 +33,6 @@
 		"symfony/expression-language": "^5.4 || ^6.0",
 		"symfony/filesystem": "^5.4 || ^6.0",
 		"symfony/finder": "^5.4 || ^6.0",
-		"symfony/polyfill-php80": "^1.25",
 		"symfony/yaml": "^5.4 || ^6.0",
 		"twig/twig": "^3.3.3",
 		"webmozart/assert": "^1.11"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d4ad4d97d9cc504749dda8a091303fba",
+    "content-hash": "4bc586abbd1c50be092af9c0bfbd64b0",
     "packages": [
         {
             "name": "cocur/slugify",
@@ -2631,89 +2631,6 @@
             ],
             "support": {
                 "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.27.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-11-03T14:55:06+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php80",
-            "version": "v1.27.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
-                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.27-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ion Bazan",
-                    "email": "ion.bazan@gmail.com"
-                },
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.27.0"
             },
             "funding": [
                 {
@@ -7163,6 +7080,89 @@
             "time": "2022-11-03T14:55:06+00:00"
         },
         {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.27.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
+                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.27-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.27.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-11-03T14:55:06+00:00"
+        },
+        {
             "name": "symfony/polyfill-php81",
             "version": "v1.27.0",
             "source": {
@@ -7421,7 +7421,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">= 7.4 < 8.2",
+        "php": "~8.0.0 || ~8.1.0",
         "ext-filter": "*",
         "ext-json": "*",
         "ext-mbstring": "*",

--- a/config/services.php
+++ b/config/services.php
@@ -40,7 +40,7 @@ use Twig\Loader;
 
 return static function (
     DependencyInjection\Loader\Configurator\ContainerConfigurator $configurator,
-    DependencyInjection\ContainerBuilder $container
+    DependencyInjection\ContainerBuilder $container,
 ): void {
     $container->registerForAutoconfiguration(Builder\Writer\WriterInterface::class)
         ->addTag('builder.writer')
@@ -65,14 +65,14 @@ return static function (
         new CompilerPass\FactoryServicesPass(
             'io.validator',
             IO\Validator\ValidatorFactory::class,
-            '$validators'
-        )
+            '$validators',
+        ),
     );
     $container->addCompilerPass(
         new CompilerPass\EventListenerPass(
             'event.listener',
-            EventDispatcher\EventDispatcherInterface::class
-        )
+            EventDispatcher\EventDispatcherInterface::class,
+        ),
     );
 
     $services = $configurator->services();

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -125,7 +125,7 @@ Example:
 ```php
 /** @var \CPSIT\ProjectBuilder\IO\InputReader $inputReader */
 
-$phpVersion = $inputReader->choices('Which PHP version should be used?', ['8.1', '8.0', '7.4']);
+$phpVersion = $inputReader->choices('Which PHP version should be used?', ['8.1', '8.0']);
 $name = $inputReader->staticValue('What\'s your name?');
 
 if ($inputReader->ask('Confirm project generation?', default: false)) {

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -12,7 +12,7 @@ There are two ways this project can be used:
 ### Requirements
 
 * Composer >= 2.1
-* PHP >= 7.4
+* PHP >= 8.0
 
 ### Basic usage
 

--- a/installer/composer.json.twig
+++ b/installer/composer.json.twig
@@ -3,7 +3,7 @@
 	"description": "Template installer for cpsit/project-builder",
 	"license": "GPL-3.0-or-later",
 	"require": {
-		"php": ">= 7.4 < 8.2",
+		"php": "~8.0.0 || ~8.1.0",
 		"composer/installers": "^2.0",
 		"oomphinc/composer-installers-extender": "^2.0",
 {% for templateSource in templateSources %}

--- a/rector.php
+++ b/rector.php
@@ -39,9 +39,9 @@ return static function (RectorConfig $rectorConfig): void {
         AddLiteralSeparatorToNumberRector::class,
     ]);
 
-    $rectorConfig->phpVersion(PhpVersion::PHP_74);
+    $rectorConfig->phpVersion(PhpVersion::PHP_80);
 
     $rectorConfig->sets([
-        LevelSetList::UP_TO_PHP_74,
+        LevelSetList::UP_TO_PHP_80,
     ]);
 };

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -46,23 +46,15 @@ use function uniqid;
  */
 final class Bootstrap
 {
-    private IO\Messenger $messenger;
-    private Builder\Config\ConfigReader $configReader;
-    private Error\ErrorHandler $errorHandler;
-    private Filesystem\Filesystem $filesystem;
     private string $targetDirectory;
 
     private function __construct(
-        IO\Messenger $messenger,
-        Builder\Config\ConfigReader $configReader,
-        Error\ErrorHandler $errorHandler,
-        Filesystem\Filesystem $filesystem,
-        string $targetDirectory = null
+        private IO\Messenger $messenger,
+        private Builder\Config\ConfigReader $configReader,
+        private Error\ErrorHandler $errorHandler,
+        private Filesystem\Filesystem $filesystem,
+        string $targetDirectory = null,
     ) {
-        $this->messenger = $messenger;
-        $this->configReader = $configReader;
-        $this->errorHandler = $errorHandler;
-        $this->filesystem = $filesystem;
         $this->targetDirectory = $targetDirectory ?? Helper\FilesystemHelper::getProjectRootPath();
     }
 
@@ -73,7 +65,7 @@ final class Bootstrap
             Builder\Config\ConfigReader::create(),
             new Error\ErrorHandler($messenger),
             new Filesystem\Filesystem(),
-            $targetDirectory
+            $targetDirectory,
         );
     }
 
@@ -86,7 +78,7 @@ final class Bootstrap
     public static function createProject(
         Script\Event $event,
         string $targetDirectory = null,
-        bool $exitOnFailure = true
+        bool $exitOnFailure = true,
     ): int {
         $messenger = IO\Messenger::create($event->getIO());
         $exitCode = self::create($messenger, $targetDirectory)->run();
@@ -152,7 +144,7 @@ final class Bootstrap
         $exitCode = $composer->install(
             Filesystem\Path::join($targetDirectory, 'composer.json'),
             true,
-            $output
+            $output,
         );
 
         if ($exitCode > 0) {
@@ -180,7 +172,7 @@ final class Bootstrap
             $io->success($message);
         }
         $io->writeln(
-            sprintf('Target directory: <comment>%s</comment>', $targetDirectory)
+            sprintf('Target directory: <comment>%s</comment>', $targetDirectory),
         );
 
         exit($exitCode);

--- a/src/Builder/BuildInstructions.php
+++ b/src/Builder/BuildInstructions.php
@@ -40,17 +40,14 @@ use function dirname;
  */
 final class BuildInstructions extends ArrayObject
 {
-    private Config\Config $config;
     private string $temporaryDirectory;
-    private string $targetDirectory;
 
-    public function __construct(Config\Config $config, string $targetDirectory)
-    {
+    public function __construct(
+        private Config\Config $config,
+        private string $targetDirectory,
+    ) {
         parent::__construct();
-
-        $this->config = $config;
         $this->temporaryDirectory = Helper\FilesystemHelper::getNewTemporaryDirectory();
-        $this->targetDirectory = $targetDirectory;
     }
 
     public function getConfig(): Config\Config
@@ -91,18 +88,12 @@ final class BuildInstructions extends ArrayObject
         return (array) $this;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getTemplateVariable(string $path)
+    public function getTemplateVariable(string $path): mixed
     {
         return Helper\ArrayHelper::getValueByPath($this, $path);
     }
 
-    /**
-     * @param mixed $value
-     */
-    public function addTemplateVariable(string $path, $value): void
+    public function addTemplateVariable(string $path, mixed $value): void
     {
         Helper\ArrayHelper::setValueByPath($this, $path, $value);
     }

--- a/src/Builder/BuildResult.php
+++ b/src/Builder/BuildResult.php
@@ -36,7 +36,6 @@ use function array_values;
  */
 final class BuildResult
 {
-    private BuildInstructions $instructions;
     private bool $mirrored = false;
 
     /**
@@ -44,9 +43,9 @@ final class BuildResult
      */
     private array $appliedSteps = [];
 
-    public function __construct(BuildInstructions $instructions)
-    {
-        $this->instructions = $instructions;
+    public function __construct(
+        private BuildInstructions $instructions,
+    ) {
     }
 
     public function getInstructions(): BuildInstructions
@@ -74,10 +73,7 @@ final class BuildResult
         return $this->appliedSteps;
     }
 
-    /**
-     * @param Generator\Step\StepInterface|string $step
-     */
-    public function isStepApplied($step): bool
+    public function isStepApplied(Generator\Step\StepInterface|string $step): bool
     {
         if ($step instanceof Generator\Step\StepInterface) {
             $step = $step::getType();
@@ -109,8 +105,8 @@ final class BuildResult
                 $files,
                 fn (Resource\Local\ProcessedFile $file): bool => Filesystem\Path::isBasePath(
                     $withinPath,
-                    $file->getTargetFile()->getPathname()
-                )
+                    $file->getTargetFile()->getPathname(),
+                ),
             );
         }
 

--- a/src/Builder/Config/Config.php
+++ b/src/Builder/Config/Config.php
@@ -33,30 +33,18 @@ use CPSIT\ProjectBuilder\Exception;
  */
 final class Config
 {
-    private string $identifier;
-    private string $name;
-
-    /**
-     * @var non-empty-list<ValueObject\Step>
-     */
-    private array $steps;
-
-    /**
-     * @var list<ValueObject\Property>
-     */
-    private array $properties;
     private ?string $declaringFile = null;
 
     /**
      * @param non-empty-list<ValueObject\Step> $steps
      * @param list<ValueObject\Property>       $properties
      */
-    public function __construct(string $identifier, string $name, array $steps, array $properties = [])
-    {
-        $this->identifier = $identifier;
-        $this->name = $name;
-        $this->steps = $steps;
-        $this->properties = $properties;
+    public function __construct(
+        private string $identifier,
+        private string $name,
+        private array $steps,
+        private array $properties = [],
+    ) {
     }
 
     public function getIdentifier(): string

--- a/src/Builder/Config/ConfigReader.php
+++ b/src/Builder/Config/ConfigReader.php
@@ -47,8 +47,6 @@ final class ConfigReader
         'config.json',
     ];
 
-    private ConfigFactory $factory;
-    private string $templateDirectory;
     private Finder\Finder $finder;
     private bool $parsed = false;
 
@@ -57,10 +55,10 @@ final class ConfigReader
      */
     private array $parsedConfig = [];
 
-    private function __construct(ConfigFactory $factory, string $templateDirectory)
-    {
-        $this->factory = $factory;
-        $this->templateDirectory = $templateDirectory;
+    private function __construct(
+        private ConfigFactory $factory,
+        private string $templateDirectory,
+    ) {
         $this->finder = $this->createFinder();
     }
 
@@ -131,7 +129,7 @@ final class ConfigReader
     {
         try {
             $composer = Resource\Local\Composer::createComposer(dirname($configFile));
-        } catch (\Exception $exception) {
+        } catch (\Exception) {
             throw Exception\InvalidConfigurationException::forMissingManifestFile($configFile);
         }
 

--- a/src/Builder/Config/ValueObject/ConditionTrait.php
+++ b/src/Builder/Config/ValueObject/ConditionTrait.php
@@ -54,7 +54,7 @@ trait ConditionTrait
     public function conditionMatches(
         ExpressionLanguage\ExpressionLanguage $expressionLanguage,
         array $additionalVariables = [],
-        bool $default = false
+        bool $default = false,
     ): bool {
         if (!$this->hasCondition()) {
             return $default;

--- a/src/Builder/Config/ValueObject/CustomizableInterface.php
+++ b/src/Builder/Config/ValueObject/CustomizableInterface.php
@@ -42,10 +42,7 @@ interface CustomizableInterface
 
     public function canHaveMultipleValues(): bool;
 
-    /**
-     * @return int|float|string|bool|null
-     */
-    public function getDefaultValue();
+    public function getDefaultValue(): int|float|string|bool|null;
 
     /**
      * @return list<PropertyValidator>

--- a/src/Builder/Config/ValueObject/FileCondition.php
+++ b/src/Builder/Config/ValueObject/FileCondition.php
@@ -33,11 +33,10 @@ final class FileCondition
 {
     use ConditionTrait;
 
-    private string $path;
-
-    public function __construct(string $path, string $if)
-    {
-        $this->path = $path;
+    public function __construct(
+        private string $path,
+        string $if,
+    ) {
         $this->if = $if;
     }
 

--- a/src/Builder/Config/ValueObject/Property.php
+++ b/src/Builder/Config/ValueObject/Property.php
@@ -37,28 +37,21 @@ final class Property
     use ValueTrait;
 
     /**
-     * @var list<SubProperty>
-     */
-    private array $properties;
-
-    /**
-     * @param int|float|string|bool|null $value
-     * @param list<SubProperty>          $properties
+     * @param list<SubProperty> $properties
      */
     public function __construct(
         string $identifier,
         string $name,
         string $path = null,
         string $if = null,
-        $value = null,
-        array $properties = []
+        int|float|string|bool|null $value = null,
+        private array $properties = [],
     ) {
         $this->identifier = $identifier;
         $this->name = $name;
         $this->path = $path;
         $this->if = $if;
         $this->value = $value;
-        $this->properties = $properties;
     }
 
     /**

--- a/src/Builder/Config/ValueObject/PropertyOption.php
+++ b/src/Builder/Config/ValueObject/PropertyOption.php
@@ -34,25 +34,11 @@ final class PropertyOption
     use ConditionTrait;
     use ValueTrait;
 
-    /**
-     * @var int|float|string
-     */
-    protected $value;
-
-    /**
-     * @param int|float|string $value
-     */
-    public function __construct($value, string $if = null)
-    {
+    public function __construct(
+        int|float|string $value,
+        string $if = null,
+    ) {
         $this->value = $value;
         $this->if = $if;
-    }
-
-    /**
-     * @return int|float|string
-     */
-    public function getValue()
-    {
-        return $this->value;
     }
 }

--- a/src/Builder/Config/ValueObject/PropertyValidator.php
+++ b/src/Builder/Config/ValueObject/PropertyValidator.php
@@ -34,17 +34,13 @@ final class PropertyValidator
     use TypeTrait;
 
     /**
-     * @var array<string, int|float|string|bool>
-     */
-    private array $options;
-
-    /**
      * @param array<string, int|float|string|bool> $options
      */
-    public function __construct(string $type, array $options = [])
-    {
+    public function __construct(
+        string $type,
+        private array $options = [],
+    ) {
         $this->type = $type;
-        $this->options = $options;
     }
 
     /**

--- a/src/Builder/Config/ValueObject/Step.php
+++ b/src/Builder/Config/ValueObject/Step.php
@@ -35,8 +35,10 @@ final class Step
 
     private StepOptions $options;
 
-    public function __construct(string $type, StepOptions $options = null)
-    {
+    public function __construct(
+        string $type,
+        StepOptions $options = null,
+    ) {
         $this->type = $type;
         $this->options = $options ?? new StepOptions();
     }

--- a/src/Builder/Config/ValueObject/StepOptions.php
+++ b/src/Builder/Config/ValueObject/StepOptions.php
@@ -32,18 +32,12 @@ namespace CPSIT\ProjectBuilder\Builder\Config\ValueObject;
 final class StepOptions
 {
     /**
-     * @var list<FileCondition>
-     */
-    private array $fileConditions;
-    private ?string $templateFile;
-
-    /**
      * @param list<FileCondition> $fileConditions
      */
-    public function __construct(array $fileConditions = [], string $templateFile = null)
-    {
-        $this->fileConditions = $fileConditions;
-        $this->templateFile = $templateFile;
+    public function __construct(
+        private array $fileConditions = [],
+        private ?string $templateFile = null,
+    ) {
     }
 
     /**

--- a/src/Builder/Config/ValueObject/SubProperty.php
+++ b/src/Builder/Config/ValueObject/SubProperty.php
@@ -40,27 +40,8 @@ final class SubProperty implements CustomizableInterface
     use ValueTrait;
 
     /**
-     * @var list<PropertyOption>
-     */
-    private array $options;
-    private bool $multiple;
-
-    /**
-     * @var int|float|string|bool|null
-     */
-    private $defaultValue;
-
-    /**
-     * @var list<PropertyValidator>
-     */
-    private array $validators;
-    private ?Property $parent;
-
-    /**
-     * @param int|float|string|bool|null $value
-     * @param list<PropertyOption>       $options
-     * @param int|float|string|bool|null $defaultValue
-     * @param list<PropertyValidator>    $validators
+     * @param list<PropertyOption>    $options
+     * @param list<PropertyValidator> $validators
      */
     public function __construct(
         string $identifier,
@@ -68,12 +49,12 @@ final class SubProperty implements CustomizableInterface
         string $type,
         string $path = null,
         string $if = null,
-        $value = null,
-        array $options = [],
-        bool $multiple = false,
-        $defaultValue = null,
-        array $validators = [],
-        ?Property $parent = null
+        int|float|string|bool|null $value = null,
+        private array $options = [],
+        private bool $multiple = false,
+        private int|float|string|bool|null $defaultValue = null,
+        private array $validators = [],
+        private ?Property $parent = null,
     ) {
         $this->identifier = $identifier;
         $this->name = $name;
@@ -81,11 +62,6 @@ final class SubProperty implements CustomizableInterface
         $this->path = $path;
         $this->if = $if;
         $this->value = $value;
-        $this->options = $options;
-        $this->multiple = $multiple;
-        $this->defaultValue = $defaultValue;
-        $this->validators = $validators;
-        $this->parent = $parent;
     }
 
     public function getPath(): string
@@ -113,7 +89,7 @@ final class SubProperty implements CustomizableInterface
         return $this->multiple;
     }
 
-    public function getDefaultValue()
+    public function getDefaultValue(): int|float|string|bool|null
     {
         return $this->defaultValue;
     }

--- a/src/Builder/Config/ValueObject/ValueTrait.php
+++ b/src/Builder/Config/ValueObject/ValueTrait.php
@@ -31,15 +31,9 @@ namespace CPSIT\ProjectBuilder\Builder\Config\ValueObject;
  */
 trait ValueTrait
 {
-    /**
-     * @var int|float|string|bool|null
-     */
-    protected $value;
+    protected int|float|string|bool|null $value;
 
-    /**
-     * @return int|float|string|bool|null
-     */
-    public function getValue()
+    public function getValue(): int|float|string|bool|null
     {
         return $this->value;
     }

--- a/src/Builder/Generator/Generator.php
+++ b/src/Builder/Generator/Generator.php
@@ -42,29 +42,18 @@ use function sprintf;
  */
 final class Generator
 {
-    private Builder\Config\Config $config;
-    private IO\Messenger $messenger;
-    private Step\StepFactory $stepFactory;
-    private Filesystem\Filesystem $filesystem;
-    private EventDispatcher\EventDispatcherInterface $eventDispatcher;
-
     /**
      * @var list<Step\StepInterface>
      */
     private array $revertedSteps = [];
 
     public function __construct(
-        Builder\Config\Config $config,
-        IO\Messenger $messenger,
-        Builder\Generator\Step\StepFactory $stepFactory,
-        Filesystem\Filesystem $filesystem,
-        EventDispatcher\EventDispatcherInterface $eventDispatcher
+        private Builder\Config\Config $config,
+        private IO\Messenger $messenger,
+        private Builder\Generator\Step\StepFactory $stepFactory,
+        private Filesystem\Filesystem $filesystem,
+        private EventDispatcher\EventDispatcherInterface $eventDispatcher,
     ) {
-        $this->config = $config;
-        $this->messenger = $messenger;
-        $this->stepFactory = $stepFactory;
-        $this->filesystem = $filesystem;
-        $this->eventDispatcher = $eventDispatcher;
     }
 
     public function run(string $targetDirectory): Builder\BuildResult
@@ -83,7 +72,7 @@ final class Generator
             $exception = null;
 
             $this->messenger->comment(
-                sprintf('Running step #%d "%s"...', $index + 1, $step->getType())
+                sprintf('Running step #%d "%s"...', $index + 1, $step->getType()),
             );
 
             try {
@@ -95,7 +84,7 @@ final class Generator
 
             if (null !== $currentStep) {
                 $this->eventDispatcher->dispatch(
-                    new Event\BuildStepProcessedEvent($currentStep, $result, $successful)
+                    new Event\BuildStepProcessedEvent($currentStep, $result, $successful),
                 );
             }
 
@@ -123,7 +112,7 @@ final class Generator
         Builder\BuildResult $result,
         string $stepType,
         Step\StepInterface $step = null,
-        Throwable $exception = null
+        Throwable $exception = null,
     ): void {
         $this->messenger->error('Project generation failed. All processed steps will be reverted.');
         $this->messenger->newLine();

--- a/src/Builder/Generator/Step/CleanUpStep.php
+++ b/src/Builder/Generator/Step/CleanUpStep.php
@@ -40,12 +40,10 @@ final class CleanUpStep extends AbstractStep
 {
     private const TYPE = 'cleanUp';
 
-    private Filesystem\Filesystem $filesystem;
-
-    public function __construct(Filesystem\Filesystem $filesystem)
-    {
+    public function __construct(
+        private Filesystem\Filesystem $filesystem,
+    ) {
         parent::__construct();
-        $this->filesystem = $filesystem;
     }
 
     public function run(Builder\BuildResult $buildResult): bool
@@ -54,7 +52,7 @@ final class CleanUpStep extends AbstractStep
 
         $directoriesToRemove = array_map(
             fn (string $path): string => Filesystem\Path::makeAbsolute($path, $targetDirectory),
-            Paths::PROTECTED_PATHS
+            Paths::PROTECTED_PATHS,
         );
 
         $this->filesystem->remove($directoriesToRemove);

--- a/src/Builder/Generator/Step/CollectBuildInstructionsStep.php
+++ b/src/Builder/Generator/Step/CollectBuildInstructionsStep.php
@@ -38,19 +38,12 @@ final class CollectBuildInstructionsStep extends AbstractStep
 {
     private const TYPE = 'collectBuildInstructions';
 
-    private ExpressionLanguage\ExpressionLanguage $expressionLanguage;
-    private IO\Messenger $messenger;
-    private Interaction\InteractionFactory $interactionFactory;
-
     public function __construct(
-        ExpressionLanguage\ExpressionLanguage $expressionLanguage,
-        IO\Messenger $messenger,
-        Interaction\InteractionFactory $interactionFactory
+        private ExpressionLanguage\ExpressionLanguage $expressionLanguage,
+        private IO\Messenger $messenger,
+        private Interaction\InteractionFactory $interactionFactory,
     ) {
         parent::__construct();
-        $this->expressionLanguage = $expressionLanguage;
-        $this->messenger = $messenger;
-        $this->interactionFactory = $interactionFactory;
     }
 
     public function run(Builder\BuildResult $buildResult): bool
@@ -133,10 +126,7 @@ final class CollectBuildInstructionsStep extends AbstractStep
         $this->apply($subProperty->getPath(), $value, $buildResult);
     }
 
-    /**
-     * @param mixed $value
-     */
-    private function apply(string $path, $value, Builder\BuildResult $buildResult): void
+    private function apply(string $path, mixed $value, Builder\BuildResult $buildResult): void
     {
         $buildResult->getInstructions()->addTemplateVariable($path, $value);
         $buildResult->applyStep($this);
@@ -144,10 +134,8 @@ final class CollectBuildInstructionsStep extends AbstractStep
 
     /**
      * @param list<Builder\Config\ValueObject\PropertyOption> $options
-     *
-     * @return int|float|string|null
      */
-    private function processOptions(array $options, Builder\BuildInstructions $instructions)
+    private function processOptions(array $options, Builder\BuildInstructions $instructions): mixed
     {
         foreach ($options as $option) {
             // A condition is required for dynamic selections

--- a/src/Builder/Generator/Step/InstallComposerDependenciesStep.php
+++ b/src/Builder/Generator/Step/InstallComposerDependenciesStep.php
@@ -40,14 +40,11 @@ final class InstallComposerDependenciesStep extends AbstractStep
 {
     private const TYPE = 'installComposerDependencies';
 
-    private Resource\Local\Composer $installer;
-    private IO\Messenger $messenger;
-
-    public function __construct(Resource\Local\Composer $installer, IO\Messenger $messenger)
-    {
+    public function __construct(
+        private Resource\Local\Composer $installer,
+        private IO\Messenger $messenger,
+    ) {
         parent::__construct();
-        $this->installer = $installer;
-        $this->messenger = $messenger;
     }
 
     public function run(Builder\BuildResult $buildResult): bool

--- a/src/Builder/Generator/Step/Interaction/InteractionFactory.php
+++ b/src/Builder/Generator/Step/Interaction/InteractionFactory.php
@@ -34,16 +34,11 @@ use CPSIT\ProjectBuilder\Exception;
 final class InteractionFactory
 {
     /**
-     * @var iterable<InteractionInterface>
-     */
-    private iterable $interactions;
-
-    /**
      * @param iterable<InteractionInterface> $interactions
      */
-    public function __construct(iterable $interactions)
-    {
-        $this->interactions = $interactions;
+    public function __construct(
+        private iterable $interactions,
+    ) {
     }
 
     public function get(string $type): InteractionInterface

--- a/src/Builder/Generator/Step/Interaction/InteractionInterface.php
+++ b/src/Builder/Generator/Step/Interaction/InteractionInterface.php
@@ -33,13 +33,10 @@ use CPSIT\ProjectBuilder\Builder;
  */
 interface InteractionInterface
 {
-    /**
-     * @return mixed
-     */
     public function interact(
         Builder\Config\ValueObject\CustomizableInterface $subject,
-        Builder\BuildInstructions $instructions
-    );
+        Builder\BuildInstructions $instructions,
+    ): mixed;
 
     public static function getType(): string;
 

--- a/src/Builder/Generator/Step/Interaction/QuestionInteraction.php
+++ b/src/Builder/Generator/Step/Interaction/QuestionInteraction.php
@@ -38,34 +38,24 @@ final class QuestionInteraction implements InteractionInterface
 {
     private const TYPE = 'question';
 
-    private ExpressionLanguage\ExpressionLanguage $expressionLanguage;
-    private IO\InputReader $reader;
-    private Twig\Renderer $renderer;
-
     public function __construct(
-        ExpressionLanguage\ExpressionLanguage $expressionLanguage,
-        IO\InputReader $reader,
-        Twig\Renderer $renderer
+        private ExpressionLanguage\ExpressionLanguage $expressionLanguage,
+        private IO\InputReader $reader,
+        private Twig\Renderer $renderer,
     ) {
-        $this->expressionLanguage = $expressionLanguage;
-        $this->reader = $reader;
-        $this->renderer = $renderer;
     }
 
-    /**
-     * @return string|bool
-     */
     public function interact(
         Builder\Config\ValueObject\CustomizableInterface $subject,
-        Builder\BuildInstructions $instructions
-    ) {
+        Builder\BuildInstructions $instructions,
+    ): string|bool {
         [$yesValue, $noValue] = $this->processOptions($subject->getOptions(), $instructions);
 
         return $this->reader->ask(
             $subject->getName(),
             $yesValue,
             $noValue,
-            (bool) $subject->getDefaultValue()
+            (bool) $subject->getDefaultValue(),
         );
     }
 
@@ -90,7 +80,7 @@ final class QuestionInteraction implements InteractionInterface
         $noValue = false;
         $matches = fn (string $condition, bool $selected): bool => (bool) $this->expressionLanguage->evaluate(
             $condition,
-            array_merge($instructions->getTemplateVariables(), ['selected' => $selected])
+            array_merge($instructions->getTemplateVariables(), ['selected' => $selected]),
         );
 
         foreach ($options as $option) {

--- a/src/Builder/Generator/Step/Interaction/SelectInteraction.php
+++ b/src/Builder/Generator/Step/Interaction/SelectInteraction.php
@@ -40,18 +40,11 @@ final class SelectInteraction implements InteractionInterface
 {
     private const TYPE = 'select';
 
-    private ExpressionLanguage\ExpressionLanguage $expressionLanguage;
-    private IO\InputReader $reader;
-    private Twig\Renderer $renderer;
-
     public function __construct(
-        ExpressionLanguage\ExpressionLanguage $expressionLanguage,
-        IO\InputReader $reader,
-        Twig\Renderer $renderer
+        private ExpressionLanguage\ExpressionLanguage $expressionLanguage,
+        private IO\InputReader $reader,
+        private Twig\Renderer $renderer,
     ) {
-        $this->expressionLanguage = $expressionLanguage;
-        $this->reader = $reader;
-        $this->renderer = $renderer;
     }
 
     /**
@@ -59,14 +52,14 @@ final class SelectInteraction implements InteractionInterface
      */
     public function interact(
         Builder\Config\ValueObject\CustomizableInterface $subject,
-        Builder\BuildInstructions $instructions
-    ) {
+        Builder\BuildInstructions $instructions,
+    ): string|array|null {
         return $this->reader->choices(
             $subject->getName(),
             $this->processOptions($subject->getOptions(), $instructions),
             $this->renderValue($subject->getDefaultValue(), $instructions),
             $subject->isRequired(),
-            $subject->canHaveMultipleValues()
+            $subject->canHaveMultipleValues(),
         );
     }
 
@@ -99,11 +92,9 @@ final class SelectInteraction implements InteractionInterface
     }
 
     /**
-     * @param int|float|string|bool|null $value
-     *
      * @phpstan-return ($value is string ? string : null)
      */
-    private function renderValue($value, Builder\BuildInstructions $instructions): ?string
+    private function renderValue(mixed $value, Builder\BuildInstructions $instructions): ?string
     {
         if (!is_string($value)) {
             return null;

--- a/src/Builder/Generator/Step/Interaction/StaticValueInteraction.php
+++ b/src/Builder/Generator/Step/Interaction/StaticValueInteraction.php
@@ -39,23 +39,16 @@ final class StaticValueInteraction implements InteractionInterface
 {
     private const TYPE = 'staticValue';
 
-    private IO\InputReader $reader;
-    private Twig\Renderer $renderer;
-    private IO\Validator\ValidatorFactory $validatorFactory;
-
     public function __construct(
-        IO\InputReader $reader,
-        Twig\Renderer $renderer,
-        IO\Validator\ValidatorFactory $validatorFactory
+        private IO\InputReader $reader,
+        private Twig\Renderer $renderer,
+        private IO\Validator\ValidatorFactory $validatorFactory,
     ) {
-        $this->reader = $reader;
-        $this->renderer = $renderer;
-        $this->validatorFactory = $validatorFactory;
     }
 
     public function interact(
         Builder\Config\ValueObject\CustomizableInterface $subject,
-        Builder\BuildInstructions $instructions
+        Builder\BuildInstructions $instructions,
     ): ?string {
         $validator = $this->validatorFactory->getAll($subject->getValidators());
         $defaultValue = $this->renderDefaultValue($subject->getDefaultValue(), $instructions);
@@ -64,7 +57,7 @@ final class StaticValueInteraction implements InteractionInterface
             $subject->getName(),
             $defaultValue,
             $subject->isRequired(),
-            $validator
+            $validator,
         );
     }
 
@@ -78,10 +71,7 @@ final class StaticValueInteraction implements InteractionInterface
         return self::TYPE === $type;
     }
 
-    /**
-     * @param mixed $defaultValue
-     */
-    private function renderDefaultValue($defaultValue, Builder\BuildInstructions $instructions): ?string
+    private function renderDefaultValue(mixed $defaultValue, Builder\BuildInstructions $instructions): ?string
     {
         if (!is_string($defaultValue)) {
             return null;

--- a/src/Builder/Generator/Step/MirrorProcessedFilesStep.php
+++ b/src/Builder/Generator/Step/MirrorProcessedFilesStep.php
@@ -45,18 +45,16 @@ final class MirrorProcessedFilesStep extends AbstractStep implements ProcessingS
 
     private const TYPE = 'mirrorProcessedFiles';
 
-    private IO\Messenger $messenger;
     private bool $stopped = false;
 
     public function __construct(
         ExpressionLanguage\ExpressionLanguage $expressionLanguage,
         Filesystem\Filesystem $filesystem,
-        IO\Messenger $messenger
+        private IO\Messenger $messenger,
     ) {
         parent::__construct();
         $this->expressionLanguage = $expressionLanguage;
         $this->filesystem = $filesystem;
-        $this->messenger = $messenger;
     }
 
     public function run(Builder\BuildResult $buildResult): bool
@@ -75,7 +73,7 @@ final class MirrorProcessedFilesStep extends AbstractStep implements ProcessingS
 
         foreach ($this->listFilesInTargetDirectory($instructions) as $file) {
             $this->messenger->progress(
-                sprintf('Removing "%s" in target directory...', $file->getRelativePathname())
+                sprintf('Removing "%s" in target directory...', $file->getRelativePathname()),
             );
 
             $this->filesystem->remove($file->getPathname());
@@ -116,13 +114,13 @@ final class MirrorProcessedFilesStep extends AbstractStep implements ProcessingS
     private function mirrorFile(Finder\SplFileInfo $file, Builder\BuildResult $result): Finder\SplFileInfo
     {
         $this->messenger->progress(
-            sprintf('Mirroring "%s" to target directory...', $file->getRelativePathname())
+            sprintf('Mirroring "%s" to target directory...', $file->getRelativePathname()),
         );
 
         $sourceFile = $file->getPathname();
         $targetFile = Helper\FilesystemHelper::createFileObject(
             $result->getInstructions()->getTargetDirectory(),
-            $file->getRelativePathname()
+            $file->getRelativePathname(),
         );
 
         $this->filesystem->copy($sourceFile, $targetFile->getPathname(), true);

--- a/src/Builder/Generator/Step/ProcessSharedSourceFilesStep.php
+++ b/src/Builder/Generator/Step/ProcessSharedSourceFilesStep.php
@@ -43,20 +43,15 @@ final class ProcessSharedSourceFilesStep extends AbstractStep implements Process
 
     private const TYPE = 'processSharedSourceFiles';
 
-    private IO\Messenger $messenger;
-    private Builder\Writer\WriterFactory $writerFactory;
-
     public function __construct(
         ExpressionLanguage\ExpressionLanguage $expressionLanguage,
         Filesystem\Filesystem $filesystem,
-        IO\Messenger $messenger,
-        Builder\Writer\WriterFactory $writerFactory
+        private IO\Messenger $messenger,
+        private Builder\Writer\WriterFactory $writerFactory,
     ) {
         parent::__construct();
         $this->expressionLanguage = $expressionLanguage;
         $this->filesystem = $filesystem;
-        $this->messenger = $messenger;
-        $this->writerFactory = $writerFactory;
     }
 
     public function run(Builder\BuildResult $buildResult): bool
@@ -65,7 +60,7 @@ final class ProcessSharedSourceFilesStep extends AbstractStep implements Process
 
         foreach ($this->listSharedSourceFiles($instructions) as $sharedSourceFile) {
             $this->messenger->progress(
-                sprintf('Processing shared source file "%s"...', $sharedSourceFile->getRelativePathname())
+                sprintf('Processing shared source file "%s"...', $sharedSourceFile->getRelativePathname()),
             );
 
             $writer = $this->writerFactory->get($sharedSourceFile->getPathname());
@@ -97,7 +92,7 @@ final class ProcessSharedSourceFilesStep extends AbstractStep implements Process
             $instructions->getSharedSourceDirectory(),
             // Include all installed shared source packages
             '*',
-            Paths::TEMPLATE_SOURCES
+            Paths::TEMPLATE_SOURCES,
         );
 
         return Finder\Finder::create()

--- a/src/Builder/Generator/Step/ProcessSourceFilesStep.php
+++ b/src/Builder/Generator/Step/ProcessSourceFilesStep.php
@@ -42,20 +42,15 @@ final class ProcessSourceFilesStep extends AbstractStep implements ProcessingSte
 
     private const TYPE = 'processSourceFiles';
 
-    private IO\Messenger $messenger;
-    private Builder\Writer\WriterFactory $writerFactory;
-
     public function __construct(
         ExpressionLanguage\ExpressionLanguage $expressionLanguage,
         Filesystem\Filesystem $filesystem,
-        IO\Messenger $messenger,
-        Builder\Writer\WriterFactory $writerFactory
+        private IO\Messenger $messenger,
+        private Builder\Writer\WriterFactory $writerFactory,
     ) {
         parent::__construct();
         $this->expressionLanguage = $expressionLanguage;
         $this->filesystem = $filesystem;
-        $this->messenger = $messenger;
-        $this->writerFactory = $writerFactory;
     }
 
     public function run(Builder\BuildResult $buildResult): bool
@@ -64,7 +59,7 @@ final class ProcessSourceFilesStep extends AbstractStep implements ProcessingSte
 
         foreach ($this->listSourceFiles($instructions) as $sourceFile) {
             $this->messenger->progress(
-                sprintf('Processing source file "%s"...', $sourceFile->getRelativePathname())
+                sprintf('Processing source file "%s"...', $sourceFile->getRelativePathname()),
             );
 
             $writer = $this->writerFactory->get($sourceFile->getPathname());

--- a/src/Builder/Generator/Step/ProcessingFilesTrait.php
+++ b/src/Builder/Generator/Step/ProcessingFilesTrait.php
@@ -72,7 +72,7 @@ trait ProcessingFilesTrait
             return $fileCondition->conditionMatches(
                 $this->expressionLanguage,
                 $instructions->getTemplateVariables(),
-                true
+                true,
             );
         }
 

--- a/src/Builder/Generator/Step/ShowNextStepsStep.php
+++ b/src/Builder/Generator/Step/ShowNextStepsStep.php
@@ -43,19 +43,12 @@ final class ShowNextStepsStep extends AbstractStep
 {
     private const TYPE = 'showNextSteps';
 
-    private Filesystem\Filesystem $filesystem;
-    private IO\Messenger $messenger;
-    private Twig\Renderer $renderer;
-
     public function __construct(
-        Filesystem\Filesystem $filesystem,
-        IO\Messenger $messenger,
-        Twig\Renderer $renderer
+        private Filesystem\Filesystem $filesystem,
+        private IO\Messenger $messenger,
+        private Twig\Renderer $renderer,
     ) {
         parent::__construct();
-        $this->filesystem = $filesystem;
-        $this->messenger = $messenger;
-        $this->renderer = $renderer;
     }
 
     public function run(Builder\BuildResult $buildResult): bool
@@ -105,7 +98,7 @@ final class ShowNextStepsStep extends AbstractStep
 
         $templateFilePath = Filesystem\Path::makeAbsolute(
             $templateFile,
-            $buildResult->getInstructions()->getTemplateDirectory()
+            $buildResult->getInstructions()->getTemplateDirectory(),
         );
 
         if (!$this->filesystem->exists($templateFilePath)) {

--- a/src/Builder/Generator/Step/StepFactory.php
+++ b/src/Builder/Generator/Step/StepFactory.php
@@ -35,16 +35,11 @@ use CPSIT\ProjectBuilder\Exception;
 final class StepFactory
 {
     /**
-     * @var iterable<StepInterface>
-     */
-    private iterable $steps;
-
-    /**
      * @param iterable<StepInterface> $steps
      */
-    public function __construct(iterable $steps)
-    {
-        $this->steps = $steps;
+    public function __construct(
+        private iterable $steps,
+    ) {
     }
 
     /**

--- a/src/Builder/Writer/GenericFileWriter.php
+++ b/src/Builder/Writer/GenericFileWriter.php
@@ -36,11 +36,9 @@ use Symfony\Component\Finder;
  */
 final class GenericFileWriter implements WriterInterface
 {
-    private Filesystem\Filesystem $filesystem;
-
-    public function __construct(Filesystem\Filesystem $filesystem)
-    {
-        $this->filesystem = $filesystem;
+    public function __construct(
+        private Filesystem\Filesystem $filesystem,
+    ) {
     }
 
     public function write(Builder\BuildInstructions $instructions, Finder\SplFileInfo $file): Finder\SplFileInfo

--- a/src/Builder/Writer/TemplateWriter.php
+++ b/src/Builder/Writer/TemplateWriter.php
@@ -37,13 +37,10 @@ use Symfony\Component\Finder;
  */
 final class TemplateWriter implements WriterInterface
 {
-    private Filesystem\Filesystem $filesystem;
-    private Twig\Renderer $renderer;
-
-    public function __construct(Filesystem\Filesystem $filesystem, Twig\Renderer $renderer)
-    {
-        $this->filesystem = $filesystem;
-        $this->renderer = $renderer;
+    public function __construct(
+        private Filesystem\Filesystem $filesystem,
+        private Twig\Renderer $renderer,
+    ) {
     }
 
     /**
@@ -52,13 +49,13 @@ final class TemplateWriter implements WriterInterface
     public function write(
         Builder\BuildInstructions $instructions,
         Finder\SplFileInfo $file,
-        array $variables = []
+        array $variables = [],
     ): Finder\SplFileInfo {
         $renderer = $this->renderer->withRootPath($file->getPath());
         $renderResult = $renderer->render($instructions, $file->getFilename(), $variables);
         $targetFile = Helper\FilesystemHelper::createFileObject(
             $instructions->getTemporaryDirectory(),
-            (string) preg_replace('/\.twig$/', '', $file->getRelativePathname())
+            (string) preg_replace('/\.twig$/', '', $file->getRelativePathname()),
         );
 
         $this->filesystem->dumpFile($targetFile->getPathname(), $renderResult);

--- a/src/Builder/Writer/WriterFactory.php
+++ b/src/Builder/Writer/WriterFactory.php
@@ -34,16 +34,11 @@ use CPSIT\ProjectBuilder\Exception;
 final class WriterFactory
 {
     /**
-     * @var iterable<WriterInterface>
-     */
-    private iterable $writers;
-
-    /**
      * @param iterable<WriterInterface> $writers
      */
-    public function __construct(iterable $writers)
-    {
-        $this->writers = $writers;
+    public function __construct(
+        private iterable $writers,
+    ) {
     }
 
     public function get(string $file): WriterInterface

--- a/src/DependencyInjection/CompilerPass/ContainerBuilderDebugDumpPass.php
+++ b/src/DependencyInjection/CompilerPass/ContainerBuilderDebugDumpPass.php
@@ -41,11 +41,9 @@ use Symfony\Component\DependencyInjection;
  */
 final class ContainerBuilderDebugDumpPass implements DependencyInjection\Compiler\CompilerPassInterface
 {
-    private string $cachePath;
-
-    public function __construct(string $cachePath)
-    {
-        $this->cachePath = $cachePath;
+    public function __construct(
+        private string $cachePath,
+    ) {
     }
 
     public function process(DependencyInjection\ContainerBuilder $container): void

--- a/src/DependencyInjection/CompilerPass/EventListenerPass.php
+++ b/src/DependencyInjection/CompilerPass/EventListenerPass.php
@@ -42,13 +42,10 @@ use function class_exists;
  */
 final class EventListenerPass implements DependencyInjection\Compiler\CompilerPassInterface
 {
-    private string $tagName;
-    private string $dispatcherId;
-
-    public function __construct(string $tagName, string $dispatcherId)
-    {
-        $this->tagName = $tagName;
-        $this->dispatcherId = $dispatcherId;
+    public function __construct(
+        private string $tagName,
+        private string $dispatcherId,
+    ) {
     }
 
     public function process(DependencyInjection\ContainerBuilder $container): void
@@ -80,7 +77,7 @@ final class EventListenerPass implements DependencyInjection\Compiler\CompilerPa
                     [
                         $event,
                         [new DependencyInjection\Reference($id), $method],
-                    ]
+                    ],
                 );
             }
         }

--- a/src/DependencyInjection/CompilerPass/FactoryServicesPass.php
+++ b/src/DependencyInjection/CompilerPass/FactoryServicesPass.php
@@ -40,15 +40,11 @@ use function ltrim;
  */
 final class FactoryServicesPass implements DependencyInjection\Compiler\CompilerPassInterface
 {
-    private string $tagName;
-    private string $factoryService;
-    private string $argumentName;
-
-    public function __construct(string $tagName, string $factoryService, string $argumentName)
-    {
-        $this->tagName = $tagName;
-        $this->factoryService = $factoryService;
-        $this->argumentName = $argumentName;
+    public function __construct(
+        private string $tagName,
+        private string $factoryService,
+        private string $argumentName,
+    ) {
     }
 
     public function process(DependencyInjection\ContainerBuilder $container): void
@@ -74,7 +70,7 @@ final class FactoryServicesPass implements DependencyInjection\Compiler\Compiler
 
         $container->findDefinition($this->factoryService)->setArgument(
             '$'.ltrim($this->argumentName, '$'),
-            $services
+            $services,
         );
     }
 }

--- a/src/DependencyInjection/ContainerFactory.php
+++ b/src/DependencyInjection/ContainerFactory.php
@@ -50,20 +50,13 @@ use function iterator_to_array;
 final class ContainerFactory
 {
     /**
-     * @var list<Finder\SplFileInfo>
-     */
-    private array $resources;
-    private ?string $containerPath;
-    private bool $debug;
-
-    /**
      * @param list<Finder\SplFileInfo> $resources
      */
-    private function __construct(array $resources, string $containerPath = null, bool $debug = false)
-    {
-        $this->resources = $resources;
-        $this->containerPath = $containerPath;
-        $this->debug = $debug;
+    private function __construct(
+        private array $resources,
+        private ?string $containerPath = null,
+        private bool $debug = false,
+    ) {
     }
 
     /**
@@ -81,7 +74,7 @@ final class ContainerFactory
                 Helper\FilesystemHelper::getProjectRootPath(),
                 Paths::PROJECT_TEMPLATES,
                 basename(dirname($config->getDeclaringFile())),
-                Paths::TEMPLATE_SERVICE_CONFIG
+                Paths::TEMPLATE_SERVICE_CONFIG,
             ),
         ];
 
@@ -93,20 +86,20 @@ final class ContainerFactory
         if (!Filesystem\Path::isAbsolute($testsRootPath)) {
             $testsRootPath = Filesystem\Path::join(
                 Helper\FilesystemHelper::getProjectRootPath(),
-                $testsRootPath
+                $testsRootPath,
             );
         }
         $resources = self::locateResources([
             Filesystem\Path::join(
                 $testsRootPath,
-                'config'
+                'config',
             ),
         ]);
         $containerPath = Filesystem\Path::join(
             Helper\FilesystemHelper::getProjectRootPath(),
             'var',
             'cache',
-            'test-container.php'
+            'test-container.php',
         );
 
         $filesystem = new Filesystem\Filesystem();
@@ -154,20 +147,15 @@ final class ContainerFactory
 
     private function createLoader(
         Finder\SplFileInfo $resource,
-        DependencyInjection\ContainerBuilder $container
+        DependencyInjection\ContainerBuilder $container,
     ): Config\Loader\LoaderInterface {
         $locator = new Config\FileLocator($resource->getPath());
 
-        switch ($resource->getExtension()) {
-            case 'yaml':
-            case 'yml':
-                return new DependencyInjection\Loader\YamlFileLoader($container, $locator);
-
-            case 'php':
-                return new DependencyInjection\Loader\PhpFileLoader($container, $locator);
-        }
-
-        throw Exception\UnsupportedTypeException::create($resource->getExtension());
+        return match ($resource->getExtension()) {
+            'yaml', 'yml' => new DependencyInjection\Loader\YamlFileLoader($container, $locator),
+            'php' => new DependencyInjection\Loader\PhpFileLoader($container, $locator),
+            default => throw Exception\UnsupportedTypeException::create($resource->getExtension()),
+        };
     }
 
     /**

--- a/src/Error/ErrorHandler.php
+++ b/src/Error/ErrorHandler.php
@@ -35,11 +35,9 @@ use Throwable;
  */
 final class ErrorHandler
 {
-    private IO\Messenger $messenger;
-
-    public function __construct(IO\Messenger $messenger)
-    {
-        $this->messenger = $messenger;
+    public function __construct(
+        private IO\Messenger $messenger,
+    ) {
     }
 
     public function handleException(Throwable $exception): void
@@ -54,7 +52,7 @@ final class ErrorHandler
 
         if (null !== $previousException) {
             $this->messenger->error(
-                'Caused by: '.$previousException->getMessage().$this->formatExceptionCode($previousException)
+                'Caused by: '.$previousException->getMessage().$this->formatExceptionCode($previousException),
             );
         }
 

--- a/src/Event/BeforeTemplateRenderedEvent.php
+++ b/src/Event/BeforeTemplateRenderedEvent.php
@@ -34,22 +34,14 @@ use Twig\Environment;
  */
 final class BeforeTemplateRenderedEvent
 {
-    private Environment $twig;
-    private Builder\BuildInstructions $instructions;
-
-    /**
-     * @var array<string, mixed>
-     */
-    private array $variables;
-
     /**
      * @param array<string, mixed> $variables
      */
-    public function __construct(Environment $twig, Builder\BuildInstructions $instructions, array $variables)
-    {
-        $this->twig = $twig;
-        $this->instructions = $instructions;
-        $this->variables = $variables;
+    public function __construct(
+        private Environment $twig,
+        private Builder\BuildInstructions $instructions,
+        private array $variables,
+    ) {
     }
 
     public function getTwig(): Environment

--- a/src/Event/BuildStepProcessedEvent.php
+++ b/src/Event/BuildStepProcessedEvent.php
@@ -33,18 +33,11 @@ use CPSIT\ProjectBuilder\Builder;
  */
 final class BuildStepProcessedEvent
 {
-    private Builder\Generator\Step\StepInterface $step;
-    private Builder\BuildResult $buildResult;
-    private bool $successful;
-
     public function __construct(
-        Builder\Generator\Step\StepInterface $step,
-        Builder\BuildResult $buildResult,
-        bool $successful
+        private Builder\Generator\Step\StepInterface $step,
+        private Builder\BuildResult $buildResult,
+        private bool $successful,
     ) {
-        $this->step = $step;
-        $this->buildResult = $buildResult;
-        $this->successful = $successful;
     }
 
     public function getStep(): Builder\Generator\Step\StepInterface

--- a/src/Event/BuildStepRevertedEvent.php
+++ b/src/Event/BuildStepRevertedEvent.php
@@ -33,13 +33,10 @@ use CPSIT\ProjectBuilder\Builder;
  */
 final class BuildStepRevertedEvent
 {
-    private Builder\Generator\Step\StepInterface $step;
-    private Builder\BuildResult $buildResult;
-
-    public function __construct(Builder\Generator\Step\StepInterface $step, Builder\BuildResult $buildResult)
-    {
-        $this->step = $step;
-        $this->buildResult = $buildResult;
+    public function __construct(
+        private Builder\Generator\Step\StepInterface $step,
+        private Builder\BuildResult $buildResult,
+    ) {
     }
 
     public function getStep(): Builder\Generator\Step\StepInterface

--- a/src/Event/ProjectBuildFinishedEvent.php
+++ b/src/Event/ProjectBuildFinishedEvent.php
@@ -33,11 +33,9 @@ use CPSIT\ProjectBuilder\Builder;
  */
 final class ProjectBuildFinishedEvent
 {
-    private Builder\BuildResult $buildResult;
-
-    public function __construct(Builder\BuildResult $buildResult)
-    {
-        $this->buildResult = $buildResult;
+    public function __construct(
+        private Builder\BuildResult $buildResult,
+    ) {
     }
 
     public function getBuildResult(): Builder\BuildResult

--- a/src/Event/ProjectBuildStartedEvent.php
+++ b/src/Event/ProjectBuildStartedEvent.php
@@ -33,11 +33,9 @@ use CPSIT\ProjectBuilder\Builder;
  */
 final class ProjectBuildStartedEvent
 {
-    private Builder\BuildInstructions $instructions;
-
-    public function __construct(Builder\BuildInstructions $instructions)
-    {
-        $this->instructions = $instructions;
+    public function __construct(
+        private Builder\BuildInstructions $instructions,
+    ) {
     }
 
     public function getInstructions(): Builder\BuildInstructions

--- a/src/Exception/HttpException.php
+++ b/src/Exception/HttpException.php
@@ -37,7 +37,7 @@ final class HttpException extends Exception
     {
         return new self(
             sprintf('Error from request to "%s" (%d): %s', $request->getUri(), $response->getStatusCode(), $response->getBody()),
-            1652861804
+            1652861804,
         );
     }
 }

--- a/src/Exception/IOException.php
+++ b/src/Exception/IOException.php
@@ -37,7 +37,7 @@ final class IOException extends Exception
     {
         return new self(
             sprintf('The file "%s" does not exist.', $file),
-            1653394006
+            1653394006,
         );
     }
 }

--- a/src/Exception/InvalidConfigurationException.php
+++ b/src/Exception/InvalidConfigurationException.php
@@ -40,7 +40,7 @@ final class InvalidConfigurationException extends Exception
     {
         return new self(
             sprintf('The config for "%s" does not exist or is not valid.', $identifier),
-            1652952150
+            1652952150,
         );
     }
 
@@ -50,9 +50,9 @@ final class InvalidConfigurationException extends Exception
             sprintf(
                 'Configuration for "%s" already exists as "%s". Please use only one config file per template!',
                 $identifier,
-                $file
+                $file,
             ),
-            1652950002
+            1652950002,
         );
     }
 
@@ -60,7 +60,7 @@ final class InvalidConfigurationException extends Exception
     {
         return new self(
             sprintf('The config file "%s" is invalid and cannot be processed.', $file),
-            1652950625
+            1652950625,
         );
     }
 
@@ -68,7 +68,7 @@ final class InvalidConfigurationException extends Exception
     {
         return new self(
             sprintf('The config source "%s" is invalid and cannot be processed.', mb_strimwidth($source, 0, 100, '…')),
-            1653058480
+            1653058480,
         );
     }
 
@@ -76,7 +76,7 @@ final class InvalidConfigurationException extends Exception
     {
         return new self(
             sprintf('Found conflicting properties "%s".', implode('", "', $properties)),
-            1652956541
+            1652956541,
         );
     }
 
@@ -95,7 +95,7 @@ final class InvalidConfigurationException extends Exception
 
         return new self(
             sprintf('The given config source does not match the config schema.%s', $decoratedErrors),
-            1653303396
+            1653303396,
         );
     }
 
@@ -103,7 +103,7 @@ final class InvalidConfigurationException extends Exception
     {
         return new self(
             sprintf('The config file for "%s" could not be determined.', $identifier),
-            1653424186
+            1653424186,
         );
     }
 
@@ -111,7 +111,7 @@ final class InvalidConfigurationException extends Exception
     {
         return new self(
             sprintf('The Composer manifest file for "%s" could not be found.', $file),
-            1664558700
+            1664558700,
         );
     }
 }

--- a/src/Exception/InvalidResourceException.php
+++ b/src/Exception/InvalidResourceException.php
@@ -35,7 +35,7 @@ final class InvalidResourceException extends Exception
     {
         return new self(
             sprintf('The requested resource "%s" is invalid or does not exist.', $name),
-            1664546950
+            1664546950,
         );
     }
 }

--- a/src/Exception/InvalidTemplateSourceException.php
+++ b/src/Exception/InvalidTemplateSourceException.php
@@ -37,7 +37,7 @@ final class InvalidTemplateSourceException extends Exception
     {
         return new self(
             sprintf('The provider "%s" does not provide any template sources.', self::decorateProvider($provider)),
-            1664557140
+            1664557140,
         );
     }
 
@@ -47,9 +47,9 @@ final class InvalidTemplateSourceException extends Exception
             sprintf(
                 'Installation of template source "%s" from provider "%s" failed.',
                 $templateSource->getPackage()->getName(),
-                self::decorateProvider($templateSource->getProvider())
+                self::decorateProvider($templateSource->getProvider()),
             ),
-            1664557307
+            1664557307,
         );
     }
 

--- a/src/Exception/StepFailureException.php
+++ b/src/Exception/StepFailureException.php
@@ -38,7 +38,7 @@ final class StepFailureException extends Exception
         return new self(
             sprintf('Running step "%s" failed. All applied steps were reverted.', $type),
             1652954290,
-            $previous
+            $previous,
         );
     }
 }

--- a/src/Exception/StringConversionException.php
+++ b/src/Exception/StringConversionException.php
@@ -35,7 +35,7 @@ final class StringConversionException extends Exception
     {
         return new self(
             sprintf('Cannot convert "%s" since it seems not to be supported for conversion.', $string),
-            1653317297
+            1653317297,
         );
     }
 }

--- a/src/Exception/TemplateRenderingException.php
+++ b/src/Exception/TemplateRenderingException.php
@@ -37,7 +37,7 @@ final class TemplateRenderingException extends Exception
     {
         return new self(
             sprintf('A template with identifier "%s" does not exist.', $identifier),
-            1653901911
+            1653901911,
         );
     }
 

--- a/src/Helper/ArrayHelper.php
+++ b/src/Helper/ArrayHelper.php
@@ -35,10 +35,8 @@ final class ArrayHelper
 {
     /**
      * @param iterable<string, mixed> $subject
-     *
-     * @return mixed
      */
-    public static function getValueByPath(iterable $subject, string $path)
+    public static function getValueByPath(iterable $subject, string $path): mixed
     {
         $pathSegments = array_filter(explode('.', $path));
         $reference = &$subject;
@@ -56,9 +54,8 @@ final class ArrayHelper
 
     /**
      * @param iterable<string, mixed> $subject
-     * @param mixed                   $value
      */
-    public static function setValueByPath(iterable &$subject, string $path, $value): void
+    public static function setValueByPath(iterable &$subject, string $path, mixed $value): void
     {
         $pathSegments = array_filter(explode('.', $path));
         $reference = &$subject;
@@ -74,10 +71,7 @@ final class ArrayHelper
         $reference = $value;
     }
 
-    /**
-     * @param mixed $subject
-     */
-    private static function pathSegmentExists($subject, string $pathSegment): bool
+    private static function pathSegmentExists(mixed $subject, string $pathSegment): bool
     {
         if (!is_array($subject) && !($subject instanceof ArrayObject)) {
             return false;

--- a/src/Helper/FilesystemHelper.php
+++ b/src/Helper/FilesystemHelper.php
@@ -43,7 +43,7 @@ final class FilesystemHelper
         return new Finder\SplFileInfo(
             Filesystem\Path::join($baseDir, $relativePathname),
             dirname($relativePathname),
-            $relativePathname
+            $relativePathname,
         );
     }
 

--- a/src/Helper/StringHelper.php
+++ b/src/Helper/StringHelper.php
@@ -40,29 +40,16 @@ final class StringHelper
      * @param StringCase::* $case
      *
      * @throws Exception\StringConversionException
-     * @throws Exception\UnsupportedTypeException
      */
     public static function convertCase(string $string, string $case): string
     {
-        switch ($case) {
-            case StringCase::LOWER:
-                return strtolower($string);
-
-            case StringCase::UPPER:
-                return strtoupper($string);
-
-            case StringCase::SNAKE:
-                return strtolower(implode('_', self::splitStringIntoChunks($string)));
-
-            case StringCase::UPPER_CAMEL:
-                return str_replace(' ', '', ucwords($string));
-
-            case StringCase::LOWER_CAMEL:
-                return str_replace(' ', '', lcfirst(ucwords($string)));
-        }
-
-        /* @phpstan-ignore-next-line */
-        throw Exception\UnsupportedTypeException::create($case);
+        return match ($case) {
+            StringCase::LOWER => strtolower($string),
+            StringCase::UPPER => strtoupper($string),
+            StringCase::SNAKE => strtolower(implode('_', self::splitStringIntoChunks($string))),
+            StringCase::UPPER_CAMEL => str_replace(' ', '', ucwords($string)),
+            StringCase::LOWER_CAMEL => str_replace(' ', '', lcfirst(ucwords($string))),
+        };
     }
 
     /**

--- a/src/IO/InputReader.php
+++ b/src/IO/InputReader.php
@@ -41,11 +41,9 @@ use function trim;
  */
 final class InputReader
 {
-    private IO\IOInterface $io;
-
-    public function __construct(IO\IOInterface $io)
-    {
-        $this->io = $io;
+    public function __construct(
+        private IO\IOInterface $io,
+    ) {
     }
 
     /**
@@ -57,7 +55,7 @@ final class InputReader
         string $label,
         string $default = null,
         bool $required = false,
-        Validator\ValidatorInterface $validator = null
+        Validator\ValidatorInterface $validator = null,
     ): ?string {
         $label = Messenger::decorateLabel($label, $default, $required);
         $validator = $this->makeValidator($validator, $required);
@@ -79,8 +77,7 @@ final class InputReader
     }
 
     /**
-     * @param list<string>     $choices
-     * @param bool|string|null $default
+     * @param list<string> $choices
      *
      * @return string|list<string>|null
      *
@@ -91,10 +88,10 @@ final class InputReader
     public function choices(
         string $label,
         array $choices,
-        $default = null,
+        bool|string|null $default = null,
         bool $required = false,
-        bool $multiple = false
-    ) {
+        bool $multiple = false,
+    ): string|array|null {
         $noSelectionIndex = null;
 
         if (!$required) {
@@ -149,7 +146,7 @@ final class InputReader
     {
         $selections = array_map(
             fn ($answer): string => $choices[(int) $answer],
-            array_filter($answers, fn ($answer): bool => $noSelectionIndex !== (int) $answer)
+            array_filter($answers, fn ($answer): bool => $noSelectionIndex !== (int) $answer),
         );
 
         // @codeCoverageIgnoreStart
@@ -187,7 +184,7 @@ final class InputReader
 
     private function makeValidator(
         Validator\ValidatorInterface $validator = null,
-        bool $required = false
+        bool $required = false,
     ): Validator\ChainedValidator {
         $chainedValidator = new Validator\ChainedValidator();
 

--- a/src/IO/Messenger.php
+++ b/src/IO/Messenger.php
@@ -49,13 +49,10 @@ final class Messenger
 {
     private static ?string $lastProgressOutput = null;
 
-    private IO\IOInterface $io;
-    private Console\Terminal $terminal;
-
-    private function __construct(IO\IOInterface $io, Console\Terminal $terminal)
-    {
-        $this->io = $io;
-        $this->terminal = $terminal;
+    private function __construct(
+        private IO\IOInterface $io,
+        private Console\Terminal $terminal,
+    ) {
     }
 
     public static function create(IO\IOInterface $io): self
@@ -112,14 +109,14 @@ final class Messenger
     {
         $labels = array_map(
             fn (Template\Provider\ProviderInterface $provider) => $provider->getName(),
-            array_values($providers)
+            array_values($providers),
         );
         $defaultIdentifier = array_key_first($providers);
 
         $index = $this->getIO()->select(
             self::decorateLabel('Which platform hosts the project template you want to create?', $defaultIdentifier),
             $labels,
-            (string) $defaultIdentifier
+            (string) $defaultIdentifier,
         );
 
         $selectedProvider = $providers[(int) $index];
@@ -159,7 +156,7 @@ final class Messenger
         $index = $this->getIO()->select(
             self::decorateLabel('Please select a project you would like to create', $defaultIdentifier),
             $labels,
-            (string) $defaultIdentifier
+            (string) $defaultIdentifier,
         );
 
         $this->newLine();
@@ -174,7 +171,7 @@ final class Messenger
             'You can go one step back and select another template provider.',
             sprintf(
                 'For more information, take a look at the <href=%s>documentation</>.',
-                'https://github.com/CPS-IT/project-builder/blob/main/docs/configuration.md'
+                'https://github.com/CPS-IT/project-builder/blob/main/docs/configuration.md',
             ),
             '',
         ]);
@@ -218,7 +215,7 @@ final class Messenger
             $this->writeWithEmoji(
                 Emoji::WHITE_HEAVY_CHECK_MARK,
                 self::$lastProgressOutput.'<info>Done</info>',
-                true
+                true,
             );
         }
     }
@@ -229,7 +226,7 @@ final class Messenger
             $this->writeWithEmoji(
                 Emoji::PROHIBITED,
                 self::$lastProgressOutput.'<error>Failed</error>',
-                true
+                true,
             );
         }
     }
@@ -272,12 +269,12 @@ final class Messenger
         if ($result->isMirrored()) {
             $this->writeWithEmoji(
                 Emoji::PARTY_POPPER,
-                '<info>Congratulations, your new project was successfully built!</info>'
+                '<info>Congratulations, your new project was successfully built!</info>',
             );
         } else {
             $this->writeWithEmoji(
                 Emoji::WOOZY_FACE,
-                '<comment>Project generation was aborted. Please try again.</comment>'
+                '<comment>Project generation was aborted. Please try again.</comment>',
             );
         }
 
@@ -376,15 +373,14 @@ final class Messenger
     }
 
     /**
-     * @param mixed        $default
      * @param list<string> $alternatives
      */
     public static function decorateLabel(
         string $label,
-        $default = null,
+        mixed $default = null,
         bool $required = true,
         array $alternatives = [],
-        bool $multiple = false
+        bool $multiple = false,
     ): string {
         $label = preg_replace('/(\s*:\s*)?$/', '', $label);
 
@@ -436,24 +432,14 @@ final class Messenger
      */
     private function checkVerbosity(int $verbosity): bool
     {
-        switch ($verbosity) {
-            case IO\IOInterface::QUIET:
-                return false;
-
-            case IO\IOInterface::NORMAL:
-                return true;
-
-            case IO\IOInterface::VERBOSE:
-                return $this->io->isVerbose();
-
-            case IO\IOInterface::VERY_VERBOSE:
-                return $this->io->isVeryVerbose();
-
-            case IO\IOInterface::DEBUG:
-                return $this->io->isDebug();
-        }
-
-        return false;
+        return match ($verbosity) {
+            IO\IOInterface::QUIET => false,
+            IO\IOInterface::NORMAL => true,
+            IO\IOInterface::VERBOSE => $this->io->isVerbose(),
+            IO\IOInterface::VERY_VERBOSE => $this->io->isVeryVerbose(),
+            IO\IOInterface::DEBUG => $this->io->isDebug(),
+            default => false,
+        };
     }
 
     private function getIO(): IO\IOInterface

--- a/src/IO/Validator/AbstractValidator.php
+++ b/src/IO/Validator/AbstractValidator.php
@@ -44,8 +44,9 @@ abstract class AbstractValidator implements ValidatorInterface
     /**
      * @param array<string, mixed> $options
      */
-    public function __construct(array $options = [])
-    {
+    public function __construct(
+        array $options = [],
+    ) {
         $this->options = array_merge(static::$defaultOptions, $options);
     }
 }

--- a/src/IO/Validator/ChainedValidator.php
+++ b/src/IO/Validator/ChainedValidator.php
@@ -41,8 +41,9 @@ final class ChainedValidator implements ValidatorInterface
     /**
      * @param list<ValidatorInterface> $validators
      */
-    public function __construct(array $validators = [])
-    {
+    public function __construct(
+        array $validators = [],
+    ) {
         foreach ($validators as $validator) {
             $this->add($validator);
         }

--- a/src/IO/Validator/ValidatorFactory.php
+++ b/src/IO/Validator/ValidatorFactory.php
@@ -35,16 +35,11 @@ use CPSIT\ProjectBuilder\Exception;
 final class ValidatorFactory
 {
     /**
-     * @var list<class-string<ValidatorInterface>>
-     */
-    private array $validators;
-
-    /**
      * @param list<class-string<ValidatorInterface>> $validators
      */
-    public function __construct(array $validators)
-    {
-        $this->validators = $validators;
+    public function __construct(
+        private array $validators,
+    ) {
     }
 
     public function get(Builder\Config\ValueObject\PropertyValidator $validator): ValidatorInterface

--- a/src/IO/Validator/ValidatorInterface.php
+++ b/src/IO/Validator/ValidatorInterface.php
@@ -36,7 +36,9 @@ interface ValidatorInterface
     /**
      * @param array<string, mixed> $options
      */
-    public function __construct(array $options = []);
+    public function __construct(
+        array $options = [],
+    );
 
     /**
      * @throws Exception\ValidationException

--- a/src/Naming/NameVariantBuilder.php
+++ b/src/Naming/NameVariantBuilder.php
@@ -39,40 +39,30 @@ use function is_string;
  */
 final class NameVariantBuilder
 {
-    private Builder\BuildInstructions $instructions;
-
-    public function __construct(Builder\BuildInstructions $instructions)
-    {
-        $this->instructions = $instructions;
+    public function __construct(
+        private Builder\BuildInstructions $instructions,
+    ) {
     }
 
     /**
      * @param NameVariant::*     $variant
      * @param StringCase::*|null $case
      *
-     * @throws Exception\UnsupportedTypeException
+     * @throws Exception\StringConversionException
      */
     public function createVariant(string $variant, string $case = null): string
     {
-        switch ($variant) {
-            case NameVariant::ABBREVIATION:
-                return $this->createAbbreviationVariant($case);
-
-            case NameVariant::SHORT_NAME:
-                return $this->createShortVariant($case);
-
-            case NameVariant::FULL_NAME:
-                return $this->createFullVariant($case);
-        }
-
-        /* @phpstan-ignore-next-line */
-        throw Exception\UnsupportedTypeException::create($variant);
+        return match ($variant) {
+            NameVariant::ABBREVIATION => $this->createAbbreviationVariant($case),
+            NameVariant::SHORT_NAME => $this->createShortVariant($case),
+            NameVariant::FULL_NAME => $this->createFullVariant($case),
+        };
     }
 
     /**
      * @param StringCase::*|null $case
      *
-     * @throws Exception\UnsupportedTypeException
+     * @throws Exception\StringConversionException
      */
     public function createShortVariant(string $case = null): string
     {
@@ -97,7 +87,7 @@ final class NameVariantBuilder
     /**
      * @param StringCase::*|null $case
      *
-     * @throws Exception\UnsupportedTypeException
+     * @throws Exception\StringConversionException
      */
     public function createAbbreviationVariant(string $case = null): string
     {
@@ -122,7 +112,7 @@ final class NameVariantBuilder
     /**
      * @param StringCase::*|null $case
      *
-     * @throws Exception\UnsupportedTypeException
+     * @throws Exception\StringConversionException
      */
     public function createFullVariant(string $case = null): string
     {

--- a/src/Resource/Http/PhpApiClient.php
+++ b/src/Resource/Http/PhpApiClient.php
@@ -40,15 +40,10 @@ use function assert;
  */
 final class PhpApiClient
 {
-    private Client\ClientInterface $client;
-    private Message\RequestFactoryInterface $requestFactory;
-
     public function __construct(
-        Client\ClientInterface $client,
-        Message\RequestFactoryInterface $requestFactory
+        private Client\ClientInterface $client,
+        private Message\RequestFactoryInterface $requestFactory,
     ) {
-        $this->client = $client;
-        $this->requestFactory = $requestFactory;
     }
 
     /**
@@ -60,7 +55,7 @@ final class PhpApiClient
         $requestUrl = Helper\StringHelper::interpolate(
             'https://www.php.net/releases/?json&version={branch}', [
                 'branch' => $branch,
-            ]
+            ],
         );
         $request = $this->requestFactory->createRequest('GET', $requestUrl);
         $response = $this->client->sendRequest($request);

--- a/src/Resource/Local/Composer.php
+++ b/src/Resource/Local/Composer.php
@@ -49,17 +49,15 @@ use function putenv;
  */
 final class Composer
 {
-    private Filesystem\Filesystem $filesystem;
-
-    public function __construct(Filesystem\Filesystem $filesystem)
-    {
-        $this->filesystem = $filesystem;
+    public function __construct(
+        private Filesystem\Filesystem $filesystem,
+    ) {
     }
 
     public function install(
         string $composerJson,
         bool $includeDevDependencies = false,
-        SymfonyConsole\Output\OutputInterface &$output = null
+        SymfonyConsole\Output\OutputInterface &$output = null,
     ): int {
         if (!$this->filesystem->exists($composerJson)) {
             throw Exception\IOException::forMissingFile($composerJson);
@@ -107,7 +105,7 @@ final class Composer
         $templatePackages = InstalledVersions::getInstalledPackagesByType('project-builder-template');
         $packages = array_filter(
             $repository->getPackages(),
-            fn (Package\BasePackage $package): bool => in_array($package->getName(), $templatePackages, true)
+            fn (Package\BasePackage $package): bool => in_array($package->getName(), $templatePackages, true),
         );
         $packages[] = $composer->getPackage();
 
@@ -131,7 +129,7 @@ final class Composer
 
         return $factory->createComposer(
             new IO\NullIO(),
-            Filesystem\Path::join($rootPath, 'composer.json')
+            Filesystem\Path::join($rootPath, 'composer.json'),
         );
     }
 }

--- a/src/Resource/Local/Git.php
+++ b/src/Resource/Local/Git.php
@@ -35,11 +35,9 @@ use function trim;
  */
 final class Git
 {
-    private Cli\Command\Runner $runner;
-
-    public function __construct(Cli\Command\Runner $runner)
-    {
-        $this->runner = $runner;
+    public function __construct(
+        private Cli\Command\Runner $runner,
+    ) {
     }
 
     public function getAuthorName(): ?string

--- a/src/Resource/Local/ProcessedFile.php
+++ b/src/Resource/Local/ProcessedFile.php
@@ -33,13 +33,10 @@ use Symfony\Component\Finder;
  */
 final class ProcessedFile
 {
-    private Finder\SplFileInfo $originalFile;
-    private Finder\SplFileInfo $targetFile;
-
-    public function __construct(Finder\SplFileInfo $originalFile, Finder\SplFileInfo $targetFile)
-    {
-        $this->originalFile = $originalFile;
-        $this->targetFile = $targetFile;
+    public function __construct(
+        private Finder\SplFileInfo $originalFile,
+        private Finder\SplFileInfo $targetFile,
+    ) {
     }
 
     public function getOriginalFile(): Finder\SplFileInfo

--- a/src/Template/Provider/BaseComposerProvider.php
+++ b/src/Template/Provider/BaseComposerProvider.php
@@ -48,27 +48,24 @@ use Twig\Loader;
 abstract class BaseComposerProvider implements ProviderInterface
 {
     protected const PACKAGE_TYPE = 'project-builder-template';
-
-    protected IO\Messenger $messenger;
-    protected Filesystem\Filesystem $filesystem;
     protected Resource\Local\Composer $composer;
     protected Environment $renderer;
     protected ComposerIO\IOInterface $io;
     protected ?Repository\RepositoryInterface $repository = null;
     protected bool $acceptInsecureConnections = false;
 
-    public function __construct(IO\Messenger $messenger, Filesystem\Filesystem $filesystem)
-    {
-        $this->messenger = $messenger;
-        $this->filesystem = $filesystem;
+    public function __construct(
+        protected IO\Messenger $messenger,
+        protected Filesystem\Filesystem $filesystem,
+    ) {
         $this->composer = new Resource\Local\Composer($this->filesystem);
         $this->renderer = new Environment(
             new Loader\FilesystemLoader([
                 Filesystem\Path::join(
                     Helper\FilesystemHelper::getProjectRootPath(),
-                    Paths::PROJECT_INSTALLER
+                    Paths::PROJECT_INSTALLER,
                 ),
-            ])
+            ]),
         );
         $this->io = new ComposerIO\BufferIO();
     }
@@ -85,7 +82,7 @@ abstract class BaseComposerProvider implements ProviderInterface
         $searchResult = $this->repository->search(
             '',
             Repository\RepositoryInterface::SEARCH_FULLTEXT,
-            self::PACKAGE_TYPE
+            self::PACKAGE_TYPE,
         );
 
         foreach ($searchResult as ['name' => $packageName]) {

--- a/src/Template/Provider/CustomComposerProvider.php
+++ b/src/Template/Provider/CustomComposerProvider.php
@@ -40,8 +40,10 @@ final class CustomComposerProvider extends BaseComposerProvider implements Custo
 {
     private ?string $url = null;
 
-    public function __construct(IO\Messenger $messenger, Filesystem\Filesystem $filesystem)
-    {
+    public function __construct(
+        IO\Messenger $messenger,
+        Filesystem\Filesystem $filesystem,
+    ) {
         parent::__construct($messenger, $filesystem);
 
         $this->io = new ComposerIO\ConsoleIO(
@@ -49,7 +51,7 @@ final class CustomComposerProvider extends BaseComposerProvider implements Custo
             Factory::createOutput(),
             new Console\Helper\HelperSet([
                 new Console\Helper\QuestionHelper(),
-            ])
+            ]),
         );
     }
 
@@ -69,7 +71,7 @@ final class CustomComposerProvider extends BaseComposerProvider implements Custo
             new IO\Validator\ChainedValidator([
                 new IO\Validator\NotEmptyValidator(),
                 new IO\Validator\UrlValidator(),
-            ])
+            ]),
         );
     }
 

--- a/src/Template/TemplateSource.php
+++ b/src/Template/TemplateSource.php
@@ -33,13 +33,10 @@ use Composer\Package;
  */
 final class TemplateSource
 {
-    private Provider\ProviderInterface $provider;
-    private Package\PackageInterface $package;
-
-    public function __construct(Provider\ProviderInterface $provider, Package\PackageInterface $package)
-    {
-        $this->provider = $provider;
-        $this->package = $package;
+    public function __construct(
+        private Provider\ProviderInterface $provider,
+        private Package\PackageInterface $package,
+    ) {
     }
 
     public function getProvider(): Provider\ProviderInterface

--- a/src/Twig/Extension/ProjectBuilderExtension.php
+++ b/src/Twig/Extension/ProjectBuilderExtension.php
@@ -37,23 +37,13 @@ use Twig\TwigFunction;
 final class ProjectBuilderExtension extends Extension\AbstractExtension
 {
     /**
-     * @var iterable<Twig\Filter\TwigFilterInterface>
-     */
-    private iterable $filters;
-
-    /**
-     * @var iterable<Twig\Func\TwigFunctionInterface>
-     */
-    private iterable $functions;
-
-    /**
      * @param iterable<Twig\Filter\TwigFilterInterface> $filters
      * @param iterable<Twig\Func\TwigFunctionInterface> $functions
      */
-    public function __construct(iterable $filters, iterable $functions)
-    {
-        $this->filters = $filters;
-        $this->functions = $functions;
+    public function __construct(
+        private iterable $filters,
+        private iterable $functions,
+    ) {
     }
 
     public function getFilters(): array

--- a/src/Twig/Filter/ConvertCaseFilter.php
+++ b/src/Twig/Filter/ConvertCaseFilter.php
@@ -41,9 +41,9 @@ final class ConvertCaseFilter implements TwigFilterInterface
     /**
      * @param StringCase::*|null $case
      *
-     * @throws Exception\UnsupportedTypeException
+     * @throws Exception\StringConversionException
      */
-    public function __invoke($input, string $case = null): string
+    public function __invoke(mixed $input, string $case = null): string
     {
         Assert\Assert::string($input);
         Assert\Assert::string($case);

--- a/src/Twig/Filter/SlugifyFilter.php
+++ b/src/Twig/Filter/SlugifyFilter.php
@@ -36,14 +36,12 @@ final class SlugifyFilter implements TwigFilterInterface
 {
     private const NAME = 'slugify';
 
-    private Slugify\Slugify $slugify;
-
-    public function __construct(Slugify\Slugify $slugify)
-    {
-        $this->slugify = $slugify;
+    public function __construct(
+        private Slugify\Slugify $slugify,
+    ) {
     }
 
-    public function __invoke($input, string $separator = null): string
+    public function __invoke(mixed $input, string $separator = null): string
     {
         Assert\Assert::string($input);
 

--- a/src/Twig/Filter/TwigFilterInterface.php
+++ b/src/Twig/Filter/TwigFilterInterface.php
@@ -31,12 +31,7 @@ namespace CPSIT\ProjectBuilder\Twig\Filter;
  */
 interface TwigFilterInterface
 {
-    /**
-     * @param mixed $input
-     *
-     * @return mixed
-     */
-    public function __invoke($input);
+    public function __invoke(mixed $input): mixed;
 
     public function getName(): string;
 

--- a/src/Twig/Func/DefaultAuthorEmailFunction.php
+++ b/src/Twig/Func/DefaultAuthorEmailFunction.php
@@ -35,11 +35,9 @@ final class DefaultAuthorEmailFunction implements TwigFunctionInterface
 {
     private const NAME = 'get_default_author_email';
 
-    private Resource\Local\Git $git;
-
-    public function __construct(Resource\Local\Git $git)
-    {
-        $this->git = $git;
+    public function __construct(
+        private Resource\Local\Git $git,
+    ) {
     }
 
     public function __invoke(): ?string

--- a/src/Twig/Func/DefaultAuthorNameFunction.php
+++ b/src/Twig/Func/DefaultAuthorNameFunction.php
@@ -35,11 +35,9 @@ final class DefaultAuthorNameFunction implements TwigFunctionInterface
 {
     private const NAME = 'get_default_author_name';
 
-    private Resource\Local\Git $git;
-
-    public function __construct(Resource\Local\Git $git)
-    {
-        $this->git = $git;
+    public function __construct(
+        private Resource\Local\Git $git,
+    ) {
     }
 
     public function __invoke(): ?string

--- a/src/Twig/Func/NameVariantFunction.php
+++ b/src/Twig/Func/NameVariantFunction.php
@@ -44,7 +44,7 @@ final class NameVariantFunction implements TwigFunctionInterface
      * @param Naming\NameVariant::*|null $variant
      * @param StringCase::*|null         $case
      *
-     * @throws Exception\UnsupportedTypeException
+     * @throws Exception\StringConversionException
      */
     public function __invoke(array $context = [], string $variant = null, string $case = null): string
     {

--- a/src/Twig/Func/PhpVersionFunction.php
+++ b/src/Twig/Func/PhpVersionFunction.php
@@ -41,11 +41,9 @@ final class PhpVersionFunction implements TwigFunctionInterface
      */
     private static array $versionCache = [];
 
-    private Resource\Http\PhpApiClient $client;
-
-    public function __construct(Resource\Http\PhpApiClient $client)
-    {
-        $this->client = $client;
+    public function __construct(
+        private Resource\Http\PhpApiClient $client,
+    ) {
     }
 
     public function __invoke(string $branch = null): string

--- a/src/Twig/Func/TwigFunctionInterface.php
+++ b/src/Twig/Func/TwigFunctionInterface.php
@@ -31,10 +31,7 @@ namespace CPSIT\ProjectBuilder\Twig\Func;
  */
 interface TwigFunctionInterface
 {
-    /**
-     * @return mixed
-     */
-    public function __invoke();
+    public function __invoke(): mixed;
 
     public function getName(): string;
 

--- a/src/Twig/Renderer.php
+++ b/src/Twig/Renderer.php
@@ -41,14 +41,12 @@ use function array_replace_recursive;
  */
 final class Renderer
 {
-    private Environment $twig;
-    private EventDispatcher\EventDispatcherInterface $eventDispatcher;
     private ?string $defaultTemplate = null;
 
-    public function __construct(Environment $twig, EventDispatcher\EventDispatcherInterface $eventDispatcher)
-    {
-        $this->twig = $twig;
-        $this->eventDispatcher = $eventDispatcher;
+    public function __construct(
+        private Environment $twig,
+        private EventDispatcher\EventDispatcherInterface $eventDispatcher,
+    ) {
     }
 
     /**
@@ -57,7 +55,7 @@ final class Renderer
     public function render(
         Builder\BuildInstructions $instructions,
         string $template = null,
-        array $variables = []
+        array $variables = [],
     ): string {
         $mergedVariables = array_replace_recursive($instructions->getTemplateVariables(), $variables);
         $event = new Event\BeforeTemplateRenderedEvent($this->twig, $instructions, $mergedVariables);
@@ -83,7 +81,7 @@ final class Renderer
     {
         try {
             $this->twig->load($template);
-        } catch (Error\Error $error) {
+        } catch (Error\Error) {
             return false;
         }
 

--- a/tests/config/services.php
+++ b/tests/config/services.php
@@ -29,7 +29,7 @@ use Symfony\Component\DependencyInjection as SymfonyDI;
 
 return static function (
     SymfonyDI\Loader\Configurator\ContainerConfigurator $configurator,
-    SymfonyDI\ContainerBuilder $container
+    SymfonyDI\ContainerBuilder $container,
 ): void {
     $container->addCompilerPass(new DependencyInjection\CompilerPass\PublicServicePass());
 

--- a/tests/src/Builder/BuildInstructionsTest.php
+++ b/tests/src/Builder/BuildInstructionsTest.php
@@ -43,7 +43,7 @@ final class BuildInstructionsTest extends Tests\ContainerAwareTestCase
     {
         $this->subject = new Src\Builder\BuildInstructions(
             self::$container->get('app.config'),
-            'foo'
+            'foo',
         );
     }
 

--- a/tests/src/Builder/BuildResultTest.php
+++ b/tests/src/Builder/BuildResultTest.php
@@ -45,7 +45,7 @@ final class BuildResultTest extends Tests\ContainerAwareTestCase
     {
         $this->instructions = new Src\Builder\BuildInstructions(
             self::$container->get('app.config'),
-            'foo'
+            'foo',
         );
         $this->subject = new Src\Builder\BuildResult($this->instructions);
     }
@@ -96,7 +96,7 @@ final class BuildResultTest extends Tests\ContainerAwareTestCase
 
         self::assertFalse($this->subject->isStepApplied('foo'));
         self::assertFalse($this->subject->isStepApplied(
-            self::$container->get(Src\Builder\Generator\Step\InstallComposerDependenciesStep::class)
+            self::$container->get(Src\Builder\Generator\Step\InstallComposerDependenciesStep::class),
         ));
     }
 
@@ -156,7 +156,7 @@ final class BuildResultTest extends Tests\ContainerAwareTestCase
     {
         return new Src\Resource\Local\ProcessedFile(
             new Finder\SplFileInfo($sourceFile, dirname($sourceFile), basename($sourceFile)),
-            new Finder\SplFileInfo($targetFile, dirname($targetFile), basename($targetFile))
+            new Finder\SplFileInfo($targetFile, dirname($targetFile), basename($targetFile)),
         );
     }
 }

--- a/tests/src/Builder/Config/ConfigFactoryTest.php
+++ b/tests/src/Builder/Config/ConfigFactoryTest.php
@@ -82,14 +82,14 @@ final class ConfigFactoryTest extends TestCase
                     new Src\Builder\Config\ValueObject\StepOptions([
                         new Src\Builder\Config\ValueObject\FileCondition('dummy-2.'.$type, 'false'),
                         new Src\Builder\Config\ValueObject\FileCondition('*-3.'.$type, 'false'),
-                    ])
+                    ]),
                 ),
                 new Src\Builder\Config\ValueObject\Step(
                     'processSharedSourceFiles',
                     new Src\Builder\Config\ValueObject\StepOptions([
                         new Src\Builder\Config\ValueObject\FileCondition('shared-dummy-2.'.$type, 'false'),
                         new Src\Builder\Config\ValueObject\FileCondition('shared-*-3.'.$type, 'false'),
-                    ])
+                    ]),
                 ),
                 new Src\Builder\Config\ValueObject\Step('mirrorProcessedFiles'),
             ],
@@ -99,7 +99,7 @@ final class ConfigFactoryTest extends TestCase
                     'Foo',
                     null,
                     'false',
-                    'foo'
+                    'foo',
                 ),
                 new Src\Builder\Config\ValueObject\Property(
                     'bar',
@@ -123,13 +123,13 @@ final class ConfigFactoryTest extends TestCase
                                     'notEmpty',
                                     [
                                         'strict' => true,
-                                    ]
+                                    ],
                                 ),
                             ],
                         ),
                     ],
                 ),
-            ]
+            ],
         );
 
         foreach (['json', 'yaml'] as $fileType) {

--- a/tests/src/Builder/Config/ConfigReaderTest.php
+++ b/tests/src/Builder/Config/ConfigReaderTest.php
@@ -41,7 +41,7 @@ final class ConfigReaderTest extends TestCase
     protected function setUp(): void
     {
         $this->subject = Src\Builder\Config\ConfigReader::create(
-            dirname(__DIR__, 2).'/Fixtures/Templates'
+            dirname(__DIR__, 2).'/Fixtures/Templates',
         );
     }
 
@@ -68,7 +68,7 @@ final class ConfigReaderTest extends TestCase
         $subject = Src\Builder\Config\ConfigReader::create($templateDirectory);
 
         $this->expectExceptionObject(
-            Src\Exception\InvalidConfigurationException::forMissingManifestFile($templateDirectory.'/Files/config.json')
+            Src\Exception\InvalidConfigurationException::forMissingManifestFile($templateDirectory.'/Files/config.json'),
         );
 
         $subject->readConfig('foo');
@@ -92,7 +92,7 @@ final class ConfigReaderTest extends TestCase
     public function readConfigThrowsExceptionIfTemplateContainsMultipleConfigFiles(): void
     {
         $subject = Src\Builder\Config\ConfigReader::create(
-            dirname(__DIR__, 2).'/Fixtures/Files'
+            dirname(__DIR__, 2).'/Fixtures/Files',
         );
 
         $this->expectException(Src\Exception\InvalidConfigurationException::class);
@@ -112,7 +112,7 @@ final class ConfigReaderTest extends TestCase
         self::assertSame('cpsit/project-builder-template-yaml', $actual->getIdentifier());
         self::assertSame(
             dirname(__DIR__, 2).'/Fixtures/Templates/yaml-template/config.yaml',
-            $actual->getDeclaringFile()
+            $actual->getDeclaringFile(),
         );
     }
 

--- a/tests/src/Builder/Config/ConfigTest.php
+++ b/tests/src/Builder/Config/ConfigTest.php
@@ -46,7 +46,7 @@ final class ConfigTest extends TestCase
             ],
             [
                 new Src\Builder\Config\ValueObject\Property('identifier', 'name'),
-            ]
+            ],
         );
     }
 
@@ -75,7 +75,7 @@ final class ConfigTest extends TestCase
             [
                 new Src\Builder\Config\ValueObject\Step('type'),
             ],
-            $this->subject->getSteps()
+            $this->subject->getSteps(),
         );
     }
 
@@ -88,7 +88,7 @@ final class ConfigTest extends TestCase
             [
                 new Src\Builder\Config\ValueObject\Property('identifier', 'name'),
             ],
-            $this->subject->getProperties()
+            $this->subject->getProperties(),
         );
     }
 

--- a/tests/src/Builder/Config/ValueObject/PropertyTest.php
+++ b/tests/src/Builder/Config/ValueObject/PropertyTest.php
@@ -48,9 +48,9 @@ final class PropertyTest extends TestCase
                 new Src\Builder\Config\ValueObject\SubProperty(
                     'identifier',
                     'name',
-                    'type'
+                    'type',
                 ),
-            ]
+            ],
         );
     }
 
@@ -64,10 +64,10 @@ final class PropertyTest extends TestCase
                 new Src\Builder\Config\ValueObject\SubProperty(
                     'identifier',
                     'name',
-                    'type'
+                    'type',
                 ),
             ],
-            $this->subject->getSubProperties()
+            $this->subject->getSubProperties(),
         );
     }
 

--- a/tests/src/Builder/Config/ValueObject/StepOptionsTest.php
+++ b/tests/src/Builder/Config/ValueObject/StepOptionsTest.php
@@ -42,7 +42,7 @@ final class StepOptionsTest extends TestCase
             [
                 new Src\Builder\Config\ValueObject\FileCondition('foo', 'bar'),
             ],
-            'foo'
+            'foo',
         );
     }
 
@@ -55,7 +55,7 @@ final class StepOptionsTest extends TestCase
             [
                 new Src\Builder\Config\ValueObject\FileCondition('foo', 'bar'),
             ],
-            $this->subject->getFileConditions()
+            $this->subject->getFileConditions(),
         );
     }
 

--- a/tests/src/Builder/Config/ValueObject/StepTest.php
+++ b/tests/src/Builder/Config/ValueObject/StepTest.php
@@ -40,7 +40,7 @@ final class StepTest extends TestCase
     {
         $this->subject = new Src\Builder\Config\ValueObject\Step(
             'foo',
-            new Src\Builder\Config\ValueObject\StepOptions()
+            new Src\Builder\Config\ValueObject\StepOptions(),
         );
     }
 
@@ -51,7 +51,7 @@ final class StepTest extends TestCase
     {
         self::assertEquals(
             new Src\Builder\Config\ValueObject\StepOptions(),
-            $this->subject->getOptions()
+            $this->subject->getOptions(),
         );
     }
 }

--- a/tests/src/Builder/Config/ValueObject/SubPropertyTest.php
+++ b/tests/src/Builder/Config/ValueObject/SubPropertyTest.php
@@ -54,7 +54,7 @@ final class SubPropertyTest extends TestCase
             [
                 new Src\Builder\Config\ValueObject\PropertyValidator('type'),
             ],
-            new Src\Builder\Config\ValueObject\Property('parent-identifier', 'name')
+            new Src\Builder\Config\ValueObject\Property('parent-identifier', 'name'),
         );
     }
 
@@ -85,7 +85,7 @@ final class SubPropertyTest extends TestCase
             [
                 new Src\Builder\Config\ValueObject\PropertyOption('value'),
             ],
-            $this->subject->getOptions()
+            $this->subject->getOptions(),
         );
     }
 
@@ -114,7 +114,7 @@ final class SubPropertyTest extends TestCase
             [
                 new Src\Builder\Config\ValueObject\PropertyValidator('type'),
             ],
-            $this->subject->getValidators()
+            $this->subject->getValidators(),
         );
     }
 
@@ -139,7 +139,7 @@ final class SubPropertyTest extends TestCase
     {
         self::assertEquals(
             new Src\Builder\Config\ValueObject\Property('parent-identifier', 'name'),
-            $this->subject->getParent()
+            $this->subject->getParent(),
         );
     }
 
@@ -153,10 +153,7 @@ final class SubPropertyTest extends TestCase
         self::assertSame($newParent, $this->subject->setParent($newParent)->getParent());
     }
 
-    /**
-     * @param mixed $value
-     */
-    private function modifySubject(string $property, $value): void
+    private function modifySubject(string $property, mixed $value): void
     {
         $reflection = new ReflectionObject($this->subject);
 

--- a/tests/src/Builder/Generator/GeneratorTest.php
+++ b/tests/src/Builder/Generator/GeneratorTest.php
@@ -108,7 +108,7 @@ final class GeneratorTest extends Tests\ContainerAwareTestCase
         self::assertCount(1, $this->subject->getRevertedSteps());
         self::assertInstanceOf(
             Src\Builder\Generator\Step\CollectBuildInstructionsStep::class,
-            $this->subject->getRevertedSteps()[0]
+            $this->subject->getRevertedSteps()[0],
         );
 
         self::assertCount(3, $this->eventListener->dispatchedEvents);
@@ -150,7 +150,7 @@ final class GeneratorTest extends Tests\ContainerAwareTestCase
 
         return $configReader->buildFromFile(
             dirname(__DIR__, 2).'/Fixtures/Templates/yaml-template/config.yaml',
-            'yaml'
+            'yaml',
         );
     }
 

--- a/tests/src/Builder/Generator/Step/CleanUpStepTest.php
+++ b/tests/src/Builder/Generator/Step/CleanUpStepTest.php
@@ -47,8 +47,8 @@ final class CleanUpStepTest extends Tests\ContainerAwareTestCase
         $this->result = new Src\Builder\BuildResult(
             new Src\Builder\BuildInstructions(
                 self::$config,
-                Src\Helper\FilesystemHelper::getNewTemporaryDirectory()
-            )
+                Src\Helper\FilesystemHelper::getNewTemporaryDirectory(),
+            ),
         );
     }
 

--- a/tests/src/Builder/Generator/Step/InstallComposerDependenciesStepTest.php
+++ b/tests/src/Builder/Generator/Step/InstallComposerDependenciesStepTest.php
@@ -48,7 +48,7 @@ final class InstallComposerDependenciesStepTest extends Tests\ContainerAwareTest
     {
         $this->subject = self::$container->get(Src\Builder\Generator\Step\InstallComposerDependenciesStep::class);
         $this->buildResult = new Src\Builder\BuildResult(
-            new Src\Builder\BuildInstructions(self::$config, 'foo')
+            new Src\Builder\BuildInstructions(self::$config, 'foo'),
         );
     }
 
@@ -72,13 +72,13 @@ final class InstallComposerDependenciesStepTest extends Tests\ContainerAwareTest
         self::$filesystem->copy(
             dirname(__DIR__, 3).'/Fixtures/Files/invalid-composer.json',
             self::$temporaryDirectory.'/composer.json',
-            true
+            true,
         );
 
         self::assertFalse($this->subject->run($this->buildResult));
         self::assertStringContainsString(
             'Your requirements could not be resolved to an installable set of packages.',
-            self::$io->getOutput()
+            self::$io->getOutput(),
         );
     }
 

--- a/tests/src/Builder/Generator/Step/Interaction/InteractionFactoryTest.php
+++ b/tests/src/Builder/Generator/Step/Interaction/InteractionFactoryTest.php
@@ -60,15 +60,15 @@ final class InteractionFactoryTest extends Tests\ContainerAwareTestCase
     {
         self::assertInstanceOf(
             Src\Builder\Generator\Step\Interaction\QuestionInteraction::class,
-            $this->subject->get('question')
+            $this->subject->get('question'),
         );
         self::assertInstanceOf(
             Src\Builder\Generator\Step\Interaction\SelectInteraction::class,
-            $this->subject->get('select')
+            $this->subject->get('select'),
         );
         self::assertInstanceOf(
             Src\Builder\Generator\Step\Interaction\StaticValueInteraction::class,
-            $this->subject->get('staticValue')
+            $this->subject->get('staticValue'),
         );
     }
 }

--- a/tests/src/Builder/Generator/Step/Interaction/QuestionInteractionTest.php
+++ b/tests/src/Builder/Generator/Step/Interaction/QuestionInteractionTest.php
@@ -102,7 +102,7 @@ final class QuestionInteractionTest extends Tests\ContainerAwareTestCase
             null,
             $options,
             false,
-            $defaultValue
+            $defaultValue,
         );
     }
 }

--- a/tests/src/Builder/Generator/Step/Interaction/SelectInteractionTest.php
+++ b/tests/src/Builder/Generator/Step/Interaction/SelectInteractionTest.php
@@ -123,7 +123,7 @@ final class SelectInteractionTest extends Tests\ContainerAwareTestCase
         array $options = [],
         bool $multiple = false,
         $defaultValue = null,
-        bool $required = false
+        bool $required = false,
     ): Src\Builder\Config\ValueObject\CustomizableInterface {
         $validators = [];
 
@@ -141,7 +141,7 @@ final class SelectInteractionTest extends Tests\ContainerAwareTestCase
             $options,
             $multiple,
             $defaultValue,
-            $validators
+            $validators,
         );
     }
 }

--- a/tests/src/Builder/Generator/Step/ProcessSharedSourceFilesStepTest.php
+++ b/tests/src/Builder/Generator/Step/ProcessSharedSourceFilesStepTest.php
@@ -44,7 +44,7 @@ final class ProcessSharedSourceFilesStepTest extends Tests\ContainerAwareTestCas
         $this->subject = self::$container->get(Src\Builder\Generator\Step\ProcessSharedSourceFilesStep::class);
         $this->subject->setConfig($step);
         $this->result = new Src\Builder\BuildResult(
-            new Src\Builder\BuildInstructions(self::$config, 'foo')
+            new Src\Builder\BuildInstructions(self::$config, 'foo'),
         );
     }
 
@@ -84,7 +84,7 @@ final class ProcessSharedSourceFilesStepTest extends Tests\ContainerAwareTestCas
 
         return $configFactory->buildFromFile(
             dirname(__DIR__, 3).'/Fixtures/Templates/yaml-template/config.yaml',
-            'yaml'
+            'yaml',
         );
     }
 

--- a/tests/src/Builder/Generator/Step/ProcessSourceFilesStepTest.php
+++ b/tests/src/Builder/Generator/Step/ProcessSourceFilesStepTest.php
@@ -44,7 +44,7 @@ final class ProcessSourceFilesStepTest extends Tests\ContainerAwareTestCase
         $this->subject = self::$container->get(Src\Builder\Generator\Step\ProcessSourceFilesStep::class);
         $this->subject->setConfig($step);
         $this->result = new Src\Builder\BuildResult(
-            new Src\Builder\BuildInstructions(self::$config, 'foo')
+            new Src\Builder\BuildInstructions(self::$config, 'foo'),
         );
     }
 
@@ -84,7 +84,7 @@ final class ProcessSourceFilesStepTest extends Tests\ContainerAwareTestCase
 
         return $configFactory->buildFromFile(
             dirname(__DIR__, 3).'/Fixtures/Templates/yaml-template/config.yaml',
-            'yaml'
+            'yaml',
         );
     }
 

--- a/tests/src/Builder/Generator/Step/ShowNextStepsStepTest.php
+++ b/tests/src/Builder/Generator/Step/ShowNextStepsStepTest.php
@@ -43,7 +43,7 @@ final class ShowNextStepsStepTest extends Tests\ContainerAwareTestCase
     {
         $this->subject = self::$container->get(Src\Builder\Generator\Step\ShowNextStepsStep::class);
         $this->result = new Src\Builder\BuildResult(
-            new Src\Builder\BuildInstructions(self::$config, 'foo')
+            new Src\Builder\BuildInstructions(self::$config, 'foo'),
         );
     }
 
@@ -67,8 +67,8 @@ final class ShowNextStepsStepTest extends Tests\ContainerAwareTestCase
         $this->subject->setConfig(
             new Src\Builder\Config\ValueObject\Step(
                 Src\Builder\Generator\Step\ShowNextStepsStep::getType(),
-                new Src\Builder\Config\ValueObject\StepOptions([], 'foo')
-            )
+                new Src\Builder\Config\ValueObject\StepOptions([], 'foo'),
+            ),
         );
 
         $this->expectException(Src\Exception\IOException::class);
@@ -88,9 +88,9 @@ final class ShowNextStepsStepTest extends Tests\ContainerAwareTestCase
                 Src\Builder\Generator\Step\ShowNextStepsStep::getType(),
                 new Src\Builder\Config\ValueObject\StepOptions(
                     [],
-                    dirname(__DIR__, 3).'/Fixtures/Files/invalid-template.twig'
-                )
-            )
+                    dirname(__DIR__, 3).'/Fixtures/Files/invalid-template.twig',
+                ),
+            ),
         );
 
         $this->expectException(Src\Exception\InvalidConfigurationException::class);
@@ -110,9 +110,9 @@ final class ShowNextStepsStepTest extends Tests\ContainerAwareTestCase
                 Src\Builder\Generator\Step\ShowNextStepsStep::getType(),
                 new Src\Builder\Config\ValueObject\StepOptions(
                     [],
-                    dirname(__DIR__, 3).'/Fixtures/Templates/yaml-template/templates/next-steps.html.twig'
-                )
-            )
+                    dirname(__DIR__, 3).'/Fixtures/Templates/yaml-template/templates/next-steps.html.twig',
+                ),
+            ),
         );
 
         $actual = $this->subject->run($this->result);

--- a/tests/src/Builder/Generator/Step/StepFactoryTest.php
+++ b/tests/src/Builder/Generator/Step/StepFactoryTest.php
@@ -64,7 +64,7 @@ final class StepFactoryTest extends Tests\ContainerAwareTestCase
 
         self::assertInstanceOf(
             Src\Builder\Generator\Step\CollectBuildInstructionsStep::class,
-            $this->subject->get($step)
+            $this->subject->get($step),
         );
     }
 }

--- a/tests/src/Builder/Writer/GenericFileWriterTest.php
+++ b/tests/src/Builder/Writer/GenericFileWriterTest.php
@@ -53,7 +53,7 @@ final class GenericFileWriterTest extends Tests\ContainerAwareTestCase
     {
         $instructions = new Src\Builder\BuildInstructions(
             self::$container->get('app.config'),
-            'foo'
+            'foo',
         );
         $sourceFile = __FILE__;
         $file = new Finder\SplFileInfo($sourceFile, dirname($sourceFile), basename($sourceFile));

--- a/tests/src/Builder/Writer/TemplateWriterTest.php
+++ b/tests/src/Builder/Writer/TemplateWriterTest.php
@@ -53,7 +53,7 @@ final class TemplateWriterTest extends Tests\ContainerAwareTestCase
     {
         $instructions = new Src\Builder\BuildInstructions(
             self::$container->get('app.config'),
-            'foo'
+            'foo',
         );
         $instructions->addTemplateVariable('foo', 'foo');
         $instructions->addTemplateVariable('bar', 'foo');

--- a/tests/src/ContainerAwareTestCase.php
+++ b/tests/src/ContainerAwareTestCase.php
@@ -79,11 +79,11 @@ abstract class ContainerAwareTestCase extends TestCase
                         new Src\Builder\Config\ValueObject\SubProperty(
                             'bar',
                             'Bar',
-                            'staticValue'
+                            'staticValue',
                         ),
                     ],
                 ),
-            ]
+            ],
         );
         $config->setDeclaringFile(__FILE__);
 
@@ -113,7 +113,7 @@ abstract class ContainerAwareTestCase extends TestCase
             200,
             null,
             ['Content-Type' => 'application/json'],
-            Utils::jsonEncode($json)
+            Utils::jsonEncode($json),
         );
     }
 

--- a/tests/src/Fixtures/DummyRunner.php
+++ b/tests/src/Fixtures/DummyRunner.php
@@ -52,7 +52,7 @@ final class DummyRunner implements Cli\Command\Runner
         }
 
         return new Cli\Command\Runner\Result(
-            new Cli\Command\Result($command->getCommand(), $expectedResult[1] ?? 0, $expectedResult[0])
+            new Cli\Command\Result($command->getCommand(), $expectedResult[1] ?? 0, $expectedResult[0]),
         );
     }
 }

--- a/tests/src/Fixtures/Templates/json-template/composer.json
+++ b/tests/src/Fixtures/Templates/json-template/composer.json
@@ -2,7 +2,7 @@
 	"name": "cpsit/project-builder-template-json",
 	"type": "project-builder-template",
 	"require": {
-		"php": ">= 7.4 < 8.2"
+		"php": "~8.0.0 || ~8.1.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^9.5"

--- a/tests/src/Fixtures/Templates/yaml-template/composer.json
+++ b/tests/src/Fixtures/Templates/yaml-template/composer.json
@@ -2,7 +2,7 @@
 	"name": "cpsit/project-builder-template-yaml",
 	"type": "project-builder-template",
 	"require": {
-		"php": ">= 7.4 < 8.2"
+		"php": "~8.0.0 || ~8.1.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^9.5"

--- a/tests/src/Helper/ArrayHelperTest.php
+++ b/tests/src/Helper/ArrayHelperTest.php
@@ -76,7 +76,7 @@ final class ArrayHelperTest extends TestCase
                 ],
                 'bar' => 'hello world!',
             ],
-            $subject
+            $subject,
         );
     }
 }

--- a/tests/src/Helper/StringHelperTest.php
+++ b/tests/src/Helper/StringHelperTest.php
@@ -26,6 +26,7 @@ namespace CPSIT\ProjectBuilder\Tests\Helper;
 use CPSIT\ProjectBuilder as Src;
 use Generator;
 use PHPUnit\Framework\TestCase;
+use UnhandledMatchError;
 
 /**
  * StringHelperTest.
@@ -52,9 +53,7 @@ final class StringHelperTest extends TestCase
      */
     public function convertCaseThrowsExceptionWhenConvertingToUnsupportedCase(): void
     {
-        $this->expectException(Src\Exception\UnsupportedTypeException::class);
-        $this->expectExceptionCode(1652800199);
-        $this->expectDeprecationMessage('The type "bar" is not supported.');
+        $this->expectException(UnhandledMatchError::class);
 
         /* @phpstan-ignore-next-line */
         Src\Helper\StringHelper::convertCase('foo', 'bar');

--- a/tests/src/IO/MessengerTest.php
+++ b/tests/src/IO/MessengerTest.php
@@ -54,7 +54,7 @@ final class MessengerTest extends Tests\ContainerAwareTestCase
     {
         $packagistProvider = new Src\Template\Provider\PackagistProvider(
             $this->subject,
-            self::$container->get(Filesystem\Filesystem::class)
+            self::$container->get(Filesystem\Filesystem::class),
         );
 
         self::$io->setUserInputs(['']);
@@ -69,7 +69,7 @@ final class MessengerTest extends Tests\ContainerAwareTestCase
     {
         $customProvider = new Src\Template\Provider\CustomComposerProvider(
             $this->subject,
-            self::$container->get(Filesystem\Filesystem::class)
+            self::$container->get(Filesystem\Filesystem::class),
         );
 
         self::$io->setUserInputs(['', 'https://www.example.com']);
@@ -97,7 +97,7 @@ final class MessengerTest extends Tests\ContainerAwareTestCase
      */
     public function selectTemplateSourceReturnsSelectedTemplateSource(
         Package\PackageInterface $package,
-        string $expected
+        string $expected,
     ): void {
         $provider = new Tests\Fixtures\DummyProvider();
         $templateSource = new Src\Template\TemplateSource($provider, $package);
@@ -129,7 +129,7 @@ final class MessengerTest extends Tests\ContainerAwareTestCase
                 '',
                 'Continue? [Y/n]',
             ]),
-            self::$io->getOutput()
+            self::$io->getOutput(),
         );
     }
 

--- a/tests/src/Naming/NameVariantBuilderTest.php
+++ b/tests/src/Naming/NameVariantBuilderTest.php
@@ -26,6 +26,7 @@ namespace CPSIT\ProjectBuilder\Tests\Naming;
 use CPSIT\ProjectBuilder as Src;
 use CPSIT\ProjectBuilder\Tests;
 use Generator;
+use UnhandledMatchError;
 use Webmozart\Assert;
 
 /**
@@ -43,7 +44,7 @@ final class NameVariantBuilderTest extends Tests\ContainerAwareTestCase
     {
         $this->instructions = new Src\Builder\BuildInstructions(
             self::$container->get('app.config'),
-            'foo'
+            'foo',
         );
         $this->subject = new Src\Naming\NameVariantBuilder($this->instructions);
     }
@@ -53,9 +54,7 @@ final class NameVariantBuilderTest extends Tests\ContainerAwareTestCase
      */
     public function createVariantThrowsExceptionIfGivenVariantIsUnsupported(): void
     {
-        $this->expectException(Src\Exception\UnsupportedTypeException::class);
-        $this->expectExceptionCode(1652800199);
-        $this->expectExceptionMessage('The type "foo" is not supported.');
+        $this->expectException(UnhandledMatchError::class);
 
         /* @phpstan-ignore-next-line */
         $this->subject->createVariant('foo');

--- a/tests/src/Template/Provider/BaseComposerProviderTest.php
+++ b/tests/src/Template/Provider/BaseComposerProviderTest.php
@@ -53,7 +53,7 @@ final class BaseComposerProviderTest extends Tests\ContainerAwareTestCase
     {
         $this->subject = new Tests\Fixtures\DummyComposerProvider(
             self::$container->get('app.messenger'),
-            self::$container->get(Filesystem\Filesystem::class)
+            self::$container->get(Filesystem\Filesystem::class),
         );
         $this->server = new MockWebServer\MockWebServer();
         $this->server->start();
@@ -75,7 +75,7 @@ final class BaseComposerProviderTest extends Tests\ContainerAwareTestCase
 
         $expectedTemplateSources = array_map(
             fn (Package\PackageInterface $package) => new Template\TemplateSource($this->subject, $package),
-            $expected
+            $expected,
         );
 
         self::assertEquals($expectedTemplateSources, $this->subject->listTemplateSources());
@@ -113,11 +113,11 @@ final class BaseComposerProviderTest extends Tests\ContainerAwareTestCase
                             ],
                         ],
                     ],
-                    JSON_THROW_ON_ERROR),
+                    JSON_THROW_ON_ERROR, ),
                 [
                     'Content-Type' => 'application/json',
-                ]
-            )
+                ],
+            ),
         );
 
         $this->subject->installTemplateSource($templateSource);

--- a/tests/src/Template/Provider/CustomComposerProviderTest.php
+++ b/tests/src/Template/Provider/CustomComposerProviderTest.php
@@ -41,7 +41,7 @@ final class CustomComposerProviderTest extends Tests\ContainerAwareTestCase
     {
         $this->subject = new Src\Template\Provider\CustomComposerProvider(
             self::$container->get('app.messenger'),
-            self::$container->get(Filesystem\Filesystem::class)
+            self::$container->get(Filesystem\Filesystem::class),
         );
     }
 

--- a/tests/src/Twig/Func/NameVariantFunctionTest.php
+++ b/tests/src/Twig/Func/NameVariantFunctionTest.php
@@ -78,7 +78,7 @@ final class NameVariantFunctionTest extends Tests\ContainerAwareTestCase
     {
         $instructions = new Src\Builder\BuildInstructions(
             self::$container->get('app.config'),
-            'foo'
+            'foo',
         );
         $instructions->addTemplateVariable('project', [
             'customer_name' => 'Foo Customer',

--- a/tests/src/Twig/RendererTest.php
+++ b/tests/src/Twig/RendererTest.php
@@ -49,7 +49,7 @@ final class RendererTest extends Tests\ContainerAwareTestCase
         ;
         $this->instructions = new Src\Builder\BuildInstructions(
             self::$container->get('app.config'),
-            'foo'
+            'foo',
         );
         $this->eventListener = self::$container->get(Tests\Fixtures\DummyTemplateRenderingEventListener::class);
     }


### PR DESCRIPTION
Since PHP 7.4 has reached EOL, we can safely drop support for it. The minimum supported PHP version is now 8.0.0. With this change, the codebase is refactored for full PHP 8.0 support, leading to several backwards-incompatible changes.