### PR TITLE
[BUGFIX] Satisfy PHP extension requirements in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /project-builder
 # Install Git and php-zip extension
 RUN apk update \
     && apk add git libzip-dev zip \
-    && docker-php-ext-install zip
+    && docker-php-ext-install zip sockets
 
 # Build project-builder artifact for later use in entrypoint
 ARG PROJECT_BUILDER_VERSION=0.0.0


### PR DESCRIPTION
`donatj/mock-webserver` requires `ext-socket` to be installed. Therefore, we must install this PHP extension in `Dockerfile` to satisfy this requirement.