### PR TITLE
[TASK] Upgrade to Composer 2.4 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM composer:2.3 AS composer
+FROM composer:2.4 AS composer
 LABEL maintainer="Elias Häußler <e.haeussler@familie-redlich.de>"
 
 FROM php:8.1-alpine


### PR DESCRIPTION
Since this library already supports Composer 2.4, we can safely upgrade to this version in the Dockerfile as well.