### PR TITLE
[BUGFIX] Fall back to dot-zero release if PHP version cannot be determined

### DIFF
--- a/tests/src/Resource/Http/PhpApiClientTest.php
+++ b/tests/src/Resource/Http/PhpApiClientTest.php
@@ -64,4 +64,14 @@ final class PhpApiClientTest extends Tests\ContainerAwareTestCase
 
         self::assertSame('8.0.10', $this->subject->getLatestStableVersion('8.0'));
     }
+
+    /**
+     * @test
+     */
+    public function getLatestStableVersionFallsBackToDotZeroReleaseIfResponseIsErroneous(): void
+    {
+        self::$mockHandler->append(self::createJsonResponse(['error' => 'Unknown version']));
+
+        self::assertSame('8.2.0', $this->subject->getLatestStableVersion('8.2'));
+    }
 }


### PR DESCRIPTION
In case the latest stable PHP version for a given branch cannot be determined with the php.net API, we now handle this situation by falling back to the dot-zero release.

This is especially needed for unreleased version branches, e.g. PHP 8.2, which now results in `8.2.0`.