### PR TITLE
[FEATURE] Measure type coverage within PHPStan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,8 @@
 		"phpstan/phpstan-webmozart-assert": "^1.2",
 		"phpunit/phpunit": "^9.5.5",
 		"rector/rector": "^0.14.8",
-		"seld/jsonlint": "^1.9"
+		"seld/jsonlint": "^1.9",
+		"symplify/phpstan-rules": "^11.1"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2fb3241a8c8526fb82c281d909efb1a1",
+    "content-hash": "3400c6d4a6de9eed9489ed649f1489f2",
     "packages": [
         {
             "name": "cocur/slugify",
@@ -4514,6 +4514,91 @@
             "time": "2022-03-03T13:19:32+00:00"
         },
         {
+            "name": "nette/utils",
+            "version": "v3.2.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/utils.git",
+                "reference": "02a54c4c872b99e4ec05c4aec54b5a06eb0f6368"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/utils/zipball/02a54c4c872b99e4ec05c4aec54b5a06eb0f6368",
+                "reference": "02a54c4c872b99e4ec05c4aec54b5a06eb0f6368",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2 <8.3"
+            },
+            "conflict": {
+                "nette/di": "<3.0.6"
+            },
+            "require-dev": {
+                "nette/tester": "~2.0",
+                "phpstan/phpstan": "^1.0",
+                "tracy/tracy": "^2.3"
+            },
+            "suggest": {
+                "ext-gd": "to use Image",
+                "ext-iconv": "to use Strings::webalize(), toAscii(), chr() and reverse()",
+                "ext-intl": "to use Strings::webalize(), toAscii(), normalize() and compare()",
+                "ext-json": "to use Nette\\Utils\\Json",
+                "ext-mbstring": "to use Strings::lower() etc...",
+                "ext-tokenizer": "to use Nette\\Utils\\Reflection::getUseStatements()",
+                "ext-xml": "to use Strings::length() etc. when mbstring is not available"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0-only",
+                "GPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "🛠  Nette Utils: lightweight utilities for string & array manipulation, image handling, safe JSON encoding/decoding, validation, slug or strong password generating etc.",
+            "homepage": "https://nette.org",
+            "keywords": [
+                "array",
+                "core",
+                "datetime",
+                "images",
+                "json",
+                "nette",
+                "paginator",
+                "password",
+                "slugify",
+                "string",
+                "unicode",
+                "utf-8",
+                "utility",
+                "validation"
+            ],
+            "support": {
+                "issues": "https://github.com/nette/utils/issues",
+                "source": "https://github.com/nette/utils/tree/v3.2.8"
+            },
+            "time": "2022-09-12T23:36:20+00:00"
+        },
+        {
             "name": "nikic/php-parser",
             "version": "v4.15.2",
             "source": {
@@ -4723,6 +4808,51 @@
                 "source": "https://github.com/phpstan/extension-installer/tree/1.2.0"
             },
             "time": "2022-10-17T12:59:16+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "1.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "6ff970a7101acfe99b3048e4bbfbc094e55c5b04"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/6ff970a7101acfe99b3048e4bbfbc094e55c5b04",
+                "reference": "6ff970a7101acfe99b3048e4bbfbc094e55c5b04",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^1.5",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^9.5",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.15.0"
+            },
+            "time": "2022-12-07T16:12:39+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -7368,6 +7498,69 @@
                 }
             ],
             "time": "2022-09-28T16:00:52+00:00"
+        },
+        {
+            "name": "symplify/phpstan-rules",
+            "version": "11.1.17",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symplify/phpstan-rules.git",
+                "reference": "238f7e5505f9f9b42c800b3fbe0dd05f511882fe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symplify/phpstan-rules/zipball/238f7e5505f9f9b42c800b3fbe0dd05f511882fe",
+                "reference": "238f7e5505f9f9b42c800b3fbe0dd05f511882fe",
+                "shasum": ""
+            },
+            "require": {
+                "nette/utils": "^3.2",
+                "nikic/php-parser": "^4.14.0",
+                "php": "^7.2|^8.0",
+                "phpstan/phpdoc-parser": "^1.6.3",
+                "phpstan/phpstan": "^1.8.1",
+                "webmozart/assert": "^1.10"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "11.1-dev"
+                },
+                "phpstan": {
+                    "includes": [
+                        "config/services/services.neon",
+                        "config/packages/cognitive-complexity/cognitive-complexity-services.neon",
+                        "config/packages/symfony/services.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symplify\\PHPStanRules\\": [
+                        "src",
+                        "packages"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Set of Symplify rules for PHPStan",
+            "support": {
+                "source": "https://github.com/symplify/phpstan-rules/tree/11.1.17"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/rectorphp",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-11-10T15:18:43+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 includes:
     - .build/vendor/phpstan/phpstan/conf/bleedingEdge.neon
+
 parameters:
     level: max
     paths:
@@ -11,3 +12,29 @@ parameters:
         - tests/bootstrap.php
     symfony:
         containerXmlPath: var/cache/test-container.xml
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\Explicit\PropertyTypeDeclarationSeaLevelRule
+        tags: [phpstan.rules.rule]
+        arguments:
+            minimalLevel: 0.99
+    -
+        class: Symplify\PHPStanRules\Rules\Explicit\ParamTypeDeclarationSeaLevelRule
+        tags: [phpstan.rules.rule]
+        arguments:
+            minimalLevel: 0.99
+    -
+        class: Symplify\PHPStanRules\Rules\Explicit\ReturnTypeDeclarationSeaLevelRule
+        tags: [phpstan.rules.rule]
+        arguments:
+            minimalLevel: 0.99
+    -
+        class: Symplify\PHPStanRules\Collector\FunctionLike\ParamTypeSeaLevelCollector
+        tags: [phpstan.collector]
+    -
+        class: Symplify\PHPStanRules\Collector\FunctionLike\ReturnTypeSeaLevelCollector
+        tags: [phpstan.collector]
+    -
+        class: Symplify\PHPStanRules\Collector\ClassLike\PropertyTypeSeaLevelCollector
+        tags: [phpstan.collector]

--- a/src/IO/InputReader.php
+++ b/src/IO/InputReader.php
@@ -125,7 +125,7 @@ final class InputReader
      *
      * @return TYes|TNo
      */
-    public function ask(string $question, $yesValue = true, $noValue = false, bool $default = true)
+    public function ask(string $question, mixed $yesValue = true, mixed $noValue = false, bool $default = true): mixed
     {
         $label = Messenger::decorateLabel($question, $default ? 'Y' : 'N', true, [$default ? 'n' : 'y']);
 


### PR DESCRIPTION
This PR is based on the great article [_How to Measure Your Type Coverage_](https://tomasvotruba.com/blog/how-to-measure-your-type-coverage/) by Tomas Votruba. It introduces type coverage measurement for PHPStan, targeting a minimum of 99% type coverage.