### PR TITLE
[BUGFIX] Exit early if current environment is unsupported

### DIFF
--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace CPSIT\ProjectBuilder;
 
 use Composer\Factory;
+use Composer\InstalledVersions;
 use Composer\Script;
 use Composer\XdebugHandler;
 use Symfony\Component\Console;
@@ -81,6 +82,12 @@ final class Bootstrap
         bool $exitOnFailure = true,
     ): int {
         $messenger = IO\Messenger::create($event->getIO());
+
+        // Early return if current environment is unsupported
+        if (self::runsOnAnUnsupportedEnvironment()) {
+            throw Exception\UnsupportedEnvironmentException::forOutdatedComposerInstallation();
+        }
+
         $exitCode = self::create($messenger, $targetDirectory)->run();
 
         $event->stopPropagation();
@@ -90,6 +97,12 @@ final class Bootstrap
         }
 
         return $exitCode;
+    }
+
+    private static function runsOnAnUnsupportedEnvironment(): bool
+    {
+        /* @phpstan-ignore-next-line */
+        return !method_exists(InstalledVersions::class, 'getInstallPath');
     }
 
     /**

--- a/src/Exception/UnsupportedEnvironmentException.php
+++ b/src/Exception/UnsupportedEnvironmentException.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/project-builder".
+ *
+ * Copyright (C) 2022 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\ProjectBuilder\Exception;
+
+/**
+ * UnsupportedEnvironmentException.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+final class UnsupportedEnvironmentException extends Exception
+{
+    public static function forOutdatedComposerInstallation(): self
+    {
+        return new self(
+            implode(PHP_EOL, [
+                'Your global Composer installation is not up to date.',
+                'Make sure that you have at least Composer 2.1 installed.',
+                'Run `composer global update --lock` and then restart project creation.',
+            ]),
+            1670607990,
+        );
+    }
+}


### PR DESCRIPTION
## Problem

When running project creation in an outdated environment, it might happen that exceptions occur, e.g. when accessing the `InstalledVersions` class. This class differs between Composer versions, e.g. classes generated with Composer 2.0 miss some required methods.

As Composer loads this class from the global installation – if present – there's no integrity check in place.

## Solution

Therefore, we're now extending the bootstrapping by an additional check whether the loaded `InstalledVersions` class meets our requirements.

If not, an exception is thrown guiding the user through the required steps to make the environment compatible.

## Alternatives

A better approach would be to get rid of the `InstalledVersions` class. Sadly, this is not a valuable solution at the moment, since we're very dependent on information provided by it, especially in terms of class loading for installed template packages.

## Related issues

- #58