### PR TITLE
[FEATURE] Set Packagist as default provider and auto-fetch template sources

### DIFF
--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -267,7 +267,6 @@ final class Bootstrap
             $templateProvider = $this->messenger->selectProvider([
                 new Template\Provider\PackagistProvider($this->messenger, $this->filesystem),
                 new Template\Provider\CustomComposerProvider($this->messenger, $this->filesystem),
-                // todo: put VcsProvider #53 here: https://github.com/CPS-IT/project-builder/pull/53
             ]);
             $templateSource = $this->messenger->selectTemplateSource($templateProvider);
         } catch (Exception\InvalidTemplateSourceException $exception) {

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -249,7 +249,8 @@ final class Bootstrap
      */
     private function selectTemplateSourceFromDefaultProvider(): Template\TemplateSource
     {
-        $templateSource = $this->messenger->selectTemplateSource(new Template\Provider\PackagistProvider($this->messenger, $this->filesystem));
+        $defaultProvider = new Template\Provider\PackagistProvider($this->messenger, $this->filesystem);
+        $templateSource = $this->messenger->selectTemplateSource($defaultProvider);
 
         if (null === $templateSource) {
             return $this->selectTemplateSource();

--- a/src/Exception/InvalidTemplateSourceException.php
+++ b/src/Exception/InvalidTemplateSourceException.php
@@ -76,6 +76,6 @@ final class InvalidTemplateSourceException extends Exception
             return $provider->getUrl();
         }
 
-        return $provider->getName();
+        return $provider::getName();
     }
 }

--- a/src/IO/Messenger.php
+++ b/src/IO/Messenger.php
@@ -164,6 +164,7 @@ final class Messenger
             (string) $defaultIdentifier,
         );
 
+        // Early return if another provider should be used
         if (array_key_last($labels) === (int) $index) {
             return null;
         }

--- a/src/IO/Messenger.php
+++ b/src/IO/Messenger.php
@@ -140,8 +140,8 @@ final class Messenger
     public function selectTemplateSource(Template\Provider\ProviderInterface $provider): ?Template\TemplateSource
     {
         $this->progress(
-            sprintf('Fetching templates %s ...', 'from '.$provider->getUrl(),
-            ), IO\IOInterface::NORMAL,
+            sprintf('Fetching templates from <href=%s>%s</> ...', $provider->getUrl(), $provider->getUrl()),
+            IO\IOInterface::NORMAL,
         );
 
         $templateSources = $provider->listTemplateSources();

--- a/src/IO/Messenger.php
+++ b/src/IO/Messenger.php
@@ -137,9 +137,12 @@ final class Messenger
     /**
      * @throws Exception\InvalidTemplateSourceException
      */
-    public function selectTemplateSource(Template\Provider\ProviderInterface $provider): Template\TemplateSource
+    public function selectTemplateSource(Template\Provider\ProviderInterface $provider): ?Template\TemplateSource
     {
-        $this->progress('Fetching available template sources...', IO\IOInterface::NORMAL);
+        $this->progress(
+            sprintf('Fetching templates %s ...', 'from '.$provider->getUrl(),
+            ), IO\IOInterface::NORMAL,
+        );
 
         $templateSources = $provider->listTemplateSources();
 
@@ -151,6 +154,8 @@ final class Messenger
         }
 
         $labels = array_map([$this, 'decorateTemplateSource'], $templateSources);
+        $labels[] = 'Try another template provider.';
+
         $defaultIdentifier = array_key_first($templateSources);
 
         $index = $this->getIO()->select(
@@ -158,6 +163,10 @@ final class Messenger
             $labels,
             (string) $defaultIdentifier,
         );
+
+        if (array_key_last($labels) === (int) $index) {
+            return null;
+        }
 
         $this->newLine();
 

--- a/src/IO/Messenger.php
+++ b/src/IO/Messenger.php
@@ -108,7 +108,7 @@ final class Messenger
     public function selectProvider(array $providers): Template\Provider\ProviderInterface
     {
         $labels = array_map(
-            fn (Template\Provider\ProviderInterface $provider) => $provider->getName(),
+            fn (Template\Provider\ProviderInterface $provider) => $provider::getName(),
             array_values($providers),
         );
         $defaultIdentifier = array_key_first($providers);

--- a/src/Template/Provider/BaseComposerProvider.php
+++ b/src/Template/Provider/BaseComposerProvider.php
@@ -53,7 +53,6 @@ abstract class BaseComposerProvider implements ProviderInterface
     protected Resource\Local\Composer $composer;
     protected Environment $renderer;
     protected ComposerIO\IOInterface $io;
-    protected ?Repository\RepositoryInterface $repository = null;
     protected bool $acceptInsecureConnections = false;
 
     public function __construct(
@@ -76,19 +75,17 @@ abstract class BaseComposerProvider implements ProviderInterface
     {
         $templateSources = [];
 
-        if (null === $this->repository) {
-            $this->repository = $this->createRepository();
-        }
+        $repository = $this->createRepository();
 
         $constraint = new Semver\Constraint\MatchAllConstraint();
-        $searchResult = $this->repository->search(
+        $searchResult = $repository->search(
             '',
             Repository\RepositoryInterface::SEARCH_FULLTEXT,
             self::PACKAGE_TYPE,
         );
 
         foreach ($searchResult as ['name' => $packageName]) {
-            $package = $this->repository->findPackage($packageName, $constraint);
+            $package = $repository->findPackage($packageName, $constraint);
 
             if (null !== $package && self::PACKAGE_TYPE === $package->getType()) {
                 $templateSources[] = $this->createTemplateSource($package);
@@ -148,10 +145,6 @@ abstract class BaseComposerProvider implements ProviderInterface
     {
         $inputReader = $this->messenger->createInputReader();
 
-        if (null === $this->repository) {
-            $this->repository = $this->createRepository();
-        }
-
         $constraint = $inputReader->staticValue(
             'Enter the version constraint to require (or leave blank to use the latest version)',
         );
@@ -162,7 +155,7 @@ abstract class BaseComposerProvider implements ProviderInterface
             $constraint = '*';
         }
 
-        $package = $this->repository->findPackage($templateSource->getPackage()->getName(), $constraint);
+        $package = $this->createRepository()->findPackage($templateSource->getPackage()->getName(), $constraint);
 
         if ($package instanceof Package\BasePackage) {
             $templateSource->setPackage($package);

--- a/src/Template/Provider/CustomComposerProvider.php
+++ b/src/Template/Provider/CustomComposerProvider.php
@@ -55,7 +55,7 @@ final class CustomComposerProvider extends BaseComposerProvider implements Custo
         );
     }
 
-    public function getName(): string
+    public static function getName(): string
     {
         return 'Custom Composer registry';
     }

--- a/src/Template/Provider/PackagistProvider.php
+++ b/src/Template/Provider/PackagistProvider.php
@@ -31,7 +31,7 @@ namespace CPSIT\ProjectBuilder\Template\Provider;
  */
 final class PackagistProvider extends BaseComposerProvider
 {
-    public function getName(): string
+    public static function getName(): string
     {
         return 'Packagist.org';
     }

--- a/src/Template/Provider/ProviderInterface.php
+++ b/src/Template/Provider/ProviderInterface.php
@@ -33,7 +33,7 @@ use CPSIT\ProjectBuilder\Template;
  */
 interface ProviderInterface
 {
-    public function getName(): string;
+    public static function getName(): string;
 
     public function getUrl(): string;
 

--- a/tests/src/Console/ApplicationTest.php
+++ b/tests/src/Console/ApplicationTest.php
@@ -41,21 +41,23 @@ use function substr_count;
 final class ApplicationTest extends Tests\ContainerAwareTestCase
 {
     private string $targetDirectory;
+    private Src\IO\Messenger $messenger;
     private Filesystem\Filesystem $filesystem;
     private Src\Tests\Fixtures\DummyProvider $templateProvider;
+    private Src\Builder\Config\ConfigReader $configReader;
     private Src\Console\Application $subject;
 
     protected function setUp(): void
     {
-        $messenger = self::$container->get('app.messenger');
-
         $this->targetDirectory = Src\Helper\FilesystemHelper::getNewTemporaryDirectory();
+        $this->messenger = self::$container->get('app.messenger');
         $this->filesystem = self::$container->get(Filesystem\Filesystem::class);
         $this->templateProvider = new Src\Tests\Fixtures\DummyProvider();
+        $this->configReader = Src\Builder\Config\ConfigReader::create(dirname(__DIR__).'/Fixtures/Templates');
         $this->subject = new Src\Console\Application(
-            $messenger,
-            Src\Builder\Config\ConfigReader::create(dirname(__DIR__).'/Fixtures/Templates'),
-            new Src\Error\ErrorHandler($messenger),
+            $this->messenger,
+            $this->configReader,
+            new Src\Error\ErrorHandler($this->messenger),
             $this->filesystem,
             $this->targetDirectory,
             [$this->templateProvider],
@@ -115,16 +117,33 @@ final class ApplicationTest extends Tests\ContainerAwareTestCase
      */
     public function runAllowsSelectingADifferentTemplateProviderIfTheSelectedProviderProvidesNoTemplates(): void
     {
-        self::$io->setUserInputs(['', 'yes', '', 'no']);
+        self::$io->setUserInputs(['yes', '', 'no']);
 
         $this->subject->run();
 
         $output = self::$io->getOutput();
 
-        self::assertStringContainsStringMultipleTimes(
-            'Which platform hosts the project template you want to create?',
-            $output,
-        );
+        self::assertStringContainsStringMultipleTimes('Fetching templates from https://www.example.com ...', $output);
+        self::assertStringContainsString('Which platform hosts the project template you want to create?', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function runAllowsSelectingADifferentTemplateProviderIfTheSelectedProviderShouldBeChanged(): void
+    {
+        $this->templateProvider->templateSources = [
+            $this->createTemplateSource(),
+        ];
+
+        self::$io->setUserInputs(['1', '']);
+
+        $this->subject->run();
+
+        $output = self::$io->getOutput();
+
+        self::assertStringContainsStringMultipleTimes('Fetching templates from https://www.example.com ...', $output);
+        self::assertStringContainsStringMultipleTimes('Try another template provider.', $output);
     }
 
     /**
@@ -178,6 +197,29 @@ final class ApplicationTest extends Tests\ContainerAwareTestCase
             'Congratulations, your new project was successfully built!',
             self::$io->getOutput(),
         );
+    }
+
+    /**
+     * @test
+     */
+    public function runUsesDefaultTemplateProvidersIfNoProvidersAreConfigured(): void
+    {
+        $subject = new Src\Console\Application(
+            $this->messenger,
+            $this->configReader,
+            new Src\Error\ErrorHandler($this->messenger),
+            $this->filesystem,
+            $this->targetDirectory,
+        );
+
+        self::$io->setUserInputs(['Try another template provider.']);
+
+        $subject->run();
+
+        $output = self::$io->getOutput();
+
+        self::assertStringContainsString(Src\Template\Provider\PackagistProvider::getName(), $output);
+        self::assertStringContainsString(Src\Template\Provider\CustomComposerProvider::getName(), $output);
     }
 
     private function createTemplateSource(): Src\Template\TemplateSource

--- a/tests/src/Fixtures/DummyComposerProvider.php
+++ b/tests/src/Fixtures/DummyComposerProvider.php
@@ -54,7 +54,7 @@ final class DummyComposerProvider extends Template\Provider\BaseComposerProvider
         return parent::createRepository();
     }
 
-    public function getName(): string
+    public static function getName(): string
     {
         return 'dummy';
     }

--- a/tests/src/Fixtures/DummyProvider.php
+++ b/tests/src/Fixtures/DummyProvider.php
@@ -43,7 +43,7 @@ final class DummyProvider implements Template\Provider\ProviderInterface
 
     public ?string $installationPath = null;
 
-    public function getName(): string
+    public static function getName(): string
     {
         return 'dummy';
     }


### PR DESCRIPTION
## Major Changes
This PR addresses the second part of the https://github.com/CPS-IT/project-builder/issues/57 where a default template source provider (in this case Packagist) is now selected. Packages are automatically fetched from this provider and are suggested to the user. This will allow first-time users to quickly get started. More experienced users are still given the opportunity to define a custom registry (and with #53 a VCS provider).

## Minor Changes

- The status information (when fetching packages from a provider) is now showing the URL making it a bit cleary to users where the project builder attempts to fetch template packages from.