### PR TITLE
[FEATURE] Allow specifying template package version constraint

### DIFF
--- a/installer/composer.json.twig
+++ b/installer/composer.json.twig
@@ -7,7 +7,7 @@
 		"composer/installers": "^2.0",
 		"oomphinc/composer-installers-extender": "^2.0",
 {% for templateSource in templateSources %}
-		"{{ templateSource.package.name }}": "*"
+		"{{ templateSource.package.name }}": "{{ templateSource.package.prettyVersion }}"
 {% endfor %}
 	},
 	"repositories": [

--- a/src/Exception/InvalidTemplateSourceException.php
+++ b/src/Exception/InvalidTemplateSourceException.php
@@ -25,6 +25,8 @@ namespace CPSIT\ProjectBuilder\Exception;
 
 use CPSIT\ProjectBuilder\Template;
 
+use function sprintf;
+
 /**
  * InvalidTemplateSourceException.
  *
@@ -50,6 +52,21 @@ final class InvalidTemplateSourceException extends Exception
                 self::decorateProvider($templateSource->getProvider()),
             ),
             1664557307,
+        );
+    }
+
+    public static function forInvalidPackageVersionConstraint(
+        Template\TemplateSource $templateSource,
+        string $constraint,
+    ): self {
+        return new self(
+            sprintf(
+                'Unable to install template package "%s" with version constraint "%s" using provider "%s".',
+                $templateSource->getPackage()->getName(),
+                $constraint,
+                self::decorateProvider($templateSource->getProvider()),
+            ),
+            1671467692,
         );
     }
 

--- a/src/Template/TemplateSource.php
+++ b/src/Template/TemplateSource.php
@@ -48,4 +48,11 @@ final class TemplateSource
     {
         return $this->package;
     }
+
+    public function setPackage(Package\PackageInterface $package): self
+    {
+        $this->package = $package;
+
+        return $this;
+    }
 }

--- a/tests/src/Template/Provider/BaseComposerProviderTest.php
+++ b/tests/src/Template/Provider/BaseComposerProviderTest.php
@@ -25,6 +25,8 @@ namespace CPSIT\ProjectBuilder\Tests\Template\Provider;
 
 use Composer\Package;
 use Composer\Repository;
+use Composer\Semver\Constraint;
+use Composer\Semver\VersionParser;
 use CPSIT\ProjectBuilder\Exception;
 use CPSIT\ProjectBuilder\Resource;
 use CPSIT\ProjectBuilder\Template;
@@ -34,8 +36,10 @@ use Generator;
 use Symfony\Component\Filesystem;
 
 use function array_map;
+use function array_reduce;
 use function dirname;
 use function json_encode;
+use function reset;
 use function sprintf;
 
 /**
@@ -86,7 +90,21 @@ final class BaseComposerProviderTest extends Tests\ContainerAwareTestCase
      */
     public function installTemplateSourceThrowsExceptionIfInstallationFails(): void
     {
-        $templateSource = new Template\TemplateSource($this->subject, $this->createPackage('foo/baz'));
+        $package = $this->createPackage('foo/baz');
+        $package->setRequires([
+            'foo/boo' => new Package\Link(
+                'foo/boo',
+                'foo/boo',
+                new Constraint\MatchAllConstraint(),
+                Package\Link::TYPE_REQUIRE,
+                '1.0.0',
+            ),
+        ]);
+        $templateSource = new Template\TemplateSource($this->subject, $package);
+
+        $this->subject->packages = [$package];
+
+        $this->mockPackagesServerResponse([$package]);
 
         $this->expectExceptionObject(Exception\InvalidTemplateSourceException::forFailedInstallation($templateSource));
 
@@ -96,35 +114,67 @@ final class BaseComposerProviderTest extends Tests\ContainerAwareTestCase
     /**
      * @test
      */
-    public function installTemplateSourceInstallsComposerPackage(): void
+    public function installTemplateSourceThrowsExceptionIfInstallationFailsWithGivenConstraint(): void
     {
-        $dumper = new Package\Dumper\ArrayDumper();
+        $package = $this->createPackage('foo/baz');
+        $templateSource = new Template\TemplateSource($this->subject, $package);
+
+        self::$io->setUserInputs(['', 'no']);
+
+        $this->expectExceptionObject(Exception\InvalidTemplateSourceException::forInvalidPackageVersionConstraint($templateSource, '*'));
+
+        $this->subject->installTemplateSource($templateSource);
+    }
+
+    /**
+     * @test
+     */
+    public function installTemplateSourceAllowsSpecifyingOtherConstraintIfInstallationFailsWithGivenConstraint(): void
+    {
         $package = $this->createPackageFromTemplateFixture();
         $templateSource = new Template\TemplateSource($this->subject, $package);
 
-        $this->server->setResponseOfPath(
-            '/packages.json',
-            new MockWebServer\Response(
-                json_encode(
-                    [
-                        'packages' => [
-                            $package->getName() => [
-                                $package->getVersion() => $dumper->dump($package),
-                            ],
-                        ],
-                    ],
-                    JSON_THROW_ON_ERROR, ),
-                [
-                    'Content-Type' => 'application/json',
-                ],
-            ),
-        );
+        $this->subject->packages = [$package];
+
+        $this->mockPackagesServerResponse([$package]);
+
+        self::$io->setUserInputs(['^2.0', 'yes', '']);
 
         $this->subject->installTemplateSource($templateSource);
 
         $output = self::$io->getOutput();
 
-        self::assertStringContainsString('Installing template source... Done', $output);
+        self::assertStringContainsString('Installing template source (1.0.0)... Done', $output);
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider installTemplateSourceInstallsComposerPackageDataProvider
+     *
+     * @param non-empty-list<Package\PackageInterface> $packages
+     */
+    public function installTemplateSourceInstallsComposerPackage(
+        array $packages,
+        string $constraint,
+        string $expected,
+    ): void {
+        $templateSource = new Template\TemplateSource($this->subject, reset($packages));
+
+        $this->subject->packages = $packages;
+
+        $this->mockPackagesServerResponse($packages);
+
+        self::$io->setUserInputs([$constraint]);
+
+        $this->subject->installTemplateSource($templateSource);
+
+        $output = self::$io->getOutput();
+
+        self::assertStringContainsString(
+            sprintf('Installing template source (%s)... Done', $expected),
+            $output,
+        );
     }
 
     /**
@@ -168,28 +218,96 @@ final class BaseComposerProviderTest extends Tests\ContainerAwareTestCase
         ];
     }
 
-    private function createPackage(string $name, string $type = 'project-builder-template'): Package\Package
+    /**
+     * @return Generator<string, array{non-empty-list<Package\PackageInterface>, string, non-empty-string}>
+     */
+    public function installTemplateSourceInstallsComposerPackageDataProvider(): Generator
     {
-        $package = new Package\Package($name, '1.0.0', '1.0.0');
+        yield 'no constraint' => [
+            [$this->createPackageFromTemplateFixture()],
+            '',
+            '1.0.0',
+        ];
+
+        yield 'constraint with one package' => [
+            [$this->createPackageFromTemplateFixture(prettyVersion: '1.1.0')],
+            '^1.0',
+            '1.1.0',
+        ];
+
+        yield 'constraint with multiple packages' => [
+            [
+                $this->createPackageFromTemplateFixture(prettyVersion: '2.0.0'),
+                $this->createPackageFromTemplateFixture(prettyVersion: '1.2.0'),
+                $this->createPackageFromTemplateFixture(prettyVersion: '1.1.23'),
+                $this->createPackageFromTemplateFixture(prettyVersion: '1.1.0'),
+                $this->createPackageFromTemplateFixture(),
+            ],
+            '~1.1.0',
+            '1.1.23',
+        ];
+    }
+
+    private function createPackage(
+        string $name,
+        string $type = 'project-builder-template',
+        string $prettyVersion = '1.0.0',
+    ): Package\Package {
+        $versionParser = new VersionParser();
+
+        $package = new Package\Package($name, $versionParser->normalize($prettyVersion), $prettyVersion);
         $package->setType($type);
 
         return $package;
     }
 
-    private function createPackageFromTemplateFixture(string $templateName = 'json-template'): Package\Package
-    {
+    private function createPackageFromTemplateFixture(
+        string $templateName = 'json-template',
+        string $prettyVersion = '1.0.0',
+    ): Package\Package {
         $fixturePath = dirname(__DIR__, 2).'/Fixtures/Templates/'.$templateName;
 
         self::assertDirectoryExists($fixturePath);
 
         $composerJson = Resource\Local\Composer::createComposer($fixturePath);
-        $package = $this->createPackage($composerJson->getPackage()->getName());
+        $package = $this->createPackage($composerJson->getPackage()->getName(), prettyVersion: $prettyVersion);
 
         $package->setDistType('path');
         $package->setDistUrl($fixturePath);
         $package->setTransportOptions(['symlink' => false]);
 
         return $package;
+    }
+
+    /**
+     * @param non-empty-list<Package\PackageInterface> $packages
+     */
+    private function mockPackagesServerResponse(array $packages): void
+    {
+        $dumper = new Package\Dumper\ArrayDumper();
+
+        $this->server->setResponseOfPath(
+            '/packages.json',
+            new MockWebServer\Response(
+                json_encode(
+                    [
+                        'packages' => array_reduce(
+                            $packages,
+                            function (array $carry, Package\PackageInterface $package) use ($dumper): array {
+                                $carry[$package->getName()][$package->getPrettyVersion()] = $dumper->dump($package);
+
+                                return $carry;
+                            },
+                            [],
+                        ),
+                    ],
+                    JSON_THROW_ON_ERROR,
+                ),
+                [
+                    'Content-Type' => 'application/json',
+                ],
+            ),
+        );
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
## Feature description

This PR extends the integration of template packages. It is now possible to optionally provide a version constraint used to install a selected template package. This is especially useful when requesting a more legacy version of a template package, which was by now not possible since we let Composer decide to select a compatible version on its own.

## Example: Default behavior using the default constraint

![image](https://user-images.githubusercontent.com/16313625/208452398-6faee6c3-479e-4ab7-99d8-2ac7ba60549c.png)

## Example: New behavior using an explicit version constraint

![image](https://user-images.githubusercontent.com/16313625/208452334-a146dad9-65dc-409e-be8b-86beb255c4c6.png)