### PR TITLE
[BUGFIX] Isolate global IO state from other test cases

### DIFF
--- a/tests/src/Builder/Generator/GeneratorTest.php
+++ b/tests/src/Builder/Generator/GeneratorTest.php
@@ -156,6 +156,8 @@ final class GeneratorTest extends Tests\ContainerAwareTestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         $this->eventListener->dispatchedEvents = [];
 
         $filesystem = new Filesystem\Filesystem();

--- a/tests/src/Builder/Generator/Step/InstallComposerDependenciesStepTest.php
+++ b/tests/src/Builder/Generator/Step/InstallComposerDependenciesStepTest.php
@@ -102,6 +102,8 @@ final class InstallComposerDependenciesStepTest extends Tests\ContainerAwareTest
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         if (self::$filesystem->exists(self::$temporaryDirectory)) {
             self::$filesystem->remove(self::$temporaryDirectory);
         }

--- a/tests/src/ClearableBufferIO.php
+++ b/tests/src/ClearableBufferIO.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/project-builder".
+ *
+ * Copyright (C) 2022 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\ProjectBuilder\Tests;
+
+use Composer\IO;
+
+use function fflush;
+use function fseek;
+
+/**
+ * ClearableBufferIO.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ *
+ * @internal
+ */
+final class ClearableBufferIO extends IO\BufferIO
+{
+    public function clear(): void
+    {
+        fseek($this->output->getStream(), 0);
+        fflush($this->output->getStream());
+    }
+}

--- a/tests/src/ContainerAwareTestCase.php
+++ b/tests/src/ContainerAwareTestCase.php
@@ -92,7 +92,7 @@ abstract class ContainerAwareTestCase extends TestCase
 
     protected static function createIO(): IO\BufferIO
     {
-        return new IO\BufferIO();
+        return new ClearableBufferIO();
     }
 
     protected static function createClient(): Client\ClientInterface
@@ -120,5 +120,12 @@ abstract class ContainerAwareTestCase extends TestCase
     protected static function createErroneousResponse(int $statusCode = 500): Message\ResponseInterface
     {
         return self::$factory->createResponse($statusCode, null, [], 'Something went wrong.');
+    }
+
+    protected function tearDown(): void
+    {
+        if (self::$io instanceof ClearableBufferIO) {
+            self::$io->clear();
+        }
     }
 }

--- a/tests/src/Template/Provider/BaseComposerProviderTest.php
+++ b/tests/src/Template/Provider/BaseComposerProviderTest.php
@@ -194,6 +194,8 @@ final class BaseComposerProviderTest extends Tests\ContainerAwareTestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         $this->server->stop();
     }
 }

--- a/tests/src/Twig/RendererTest.php
+++ b/tests/src/Twig/RendererTest.php
@@ -158,6 +158,8 @@ final class RendererTest extends Tests\ContainerAwareTestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         $this->eventListener->dispatched = false;
         $this->eventListener->variables = [];
     }


### PR DESCRIPTION
The stored output within the global IO must not be available in other test cases than the current one. Therefore, we now clear the output on each `tearDown()`, resetting the internal state as required.