### PR TITLE
[BUGFIX] Streamline usage of project root paths

### DIFF
--- a/src/Builder/Config/ConfigFactory.php
+++ b/src/Builder/Config/ConfigFactory.php
@@ -34,7 +34,6 @@ use stdClass;
 use Symfony\Component\Filesystem;
 use Symfony\Component\Yaml;
 
-use function dirname;
 use function json_decode;
 
 /**
@@ -101,7 +100,7 @@ final class ConfigFactory
 
     private function validateConfig(stdClass $parsedContent): JsonSchema\ValidationResult
     {
-        $schemaFile = Filesystem\Path::join(dirname(__DIR__, 3), Paths::PROJECT_SCHEMA_CONFIG);
+        $schemaFile = Filesystem\Path::join(Helper\FilesystemHelper::getProjectRootPath(), Paths::PROJECT_SCHEMA_CONFIG);
         $schemaReference = 'file://'.$schemaFile;
         $schemaResolver = $this->validator->resolver();
 

--- a/src/Builder/Config/ConfigReader.php
+++ b/src/Builder/Config/ConfigReader.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace CPSIT\ProjectBuilder\Builder\Config;
 
 use CPSIT\ProjectBuilder\Exception;
+use CPSIT\ProjectBuilder\Helper;
 use CPSIT\ProjectBuilder\Paths;
 use CPSIT\ProjectBuilder\Resource;
 use Symfony\Component\Filesystem;
@@ -64,7 +65,7 @@ final class ConfigReader
 
     public static function create(string $templateDirectory = null): self
     {
-        $templateDirectory ??= Filesystem\Path::join(dirname(__DIR__, 3), Paths::PROJECT_TEMPLATES);
+        $templateDirectory ??= Filesystem\Path::join(Helper\FilesystemHelper::getProjectRootPath(), Paths::PROJECT_TEMPLATES);
 
         return new self(ConfigFactory::create(), $templateDirectory);
     }


### PR DESCRIPTION
This PR streamlines handling of the project root path to make the library act as expected across the whole codebase. Only two implementations are left out:

* `Bootstrap::simulateCreateProject()`: In this case, we must explicitly reference the current codebase rather than calculating any path to make sure the simulation is based on the correct (probably uncommitted) files.
* `Helper\FilesystemHelper::getProjectRootPath()`: In this case, the `dirname(__DIR__, 2)` acts only as last resort in case root path calculation has failed in all previous steps (determination via env variable and from `Composer\InstalledVersions`).

Resolves: #62