### PR TITLE
[TASK] Decouple application logic from bootstrapping

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -10,6 +10,7 @@ services:
       - '../src/Builder/Config/*'
       - '../src/Builder/BuildInstructions.php'
       - '../src/Builder/BuildResult.php'
+      - '../src/Console/*'
       - '../src/DependencyInjection/*'
       - '../src/Event/*'
       - '../src/Naming/NameVariantBuilder.php'

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,8 +17,9 @@ these three concepts:
 ### Bootstrapping
 
 Each project build is initialized by the [`Bootstrap`](../src/Bootstrap.php) class.
-This class triggers a new build and handles the build result. When a user executes
-the `composer create-project` command, the bootstrapping process is triggered.
+This class constructs the [`Application`](../src/Console/Application.php) that
+triggers a new build and handles the build result. When a user executes the
+`composer create-project` command, the bootstrapping process is triggered.
 
 > :bulb: See [`Bootstrap::createProject()`](../src/Bootstrap.php) which is defined as
 > `post-create-project-cmd` script in [`composer.json`](../composer.json).

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -32,6 +32,8 @@ use Symfony\Component\Filesystem;
  *
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-3.0-or-later
+ *
+ * @codeCoverageIgnore
  */
 final class Bootstrap
 {

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -90,27 +90,13 @@ final class Bootstrap
 
     private static function createApplication(IO\Messenger $messenger, string $targetDirectory): Console\Application
     {
-        $filesystem = new Filesystem\Filesystem();
-
         return new Console\Application(
             $messenger,
             Builder\Config\ConfigReader::create(),
             new Error\ErrorHandler($messenger),
-            $filesystem,
+            new Filesystem\Filesystem(),
             $targetDirectory,
-            self::createTemplateProviders($messenger, $filesystem),
         );
-    }
-
-    /**
-     * @return non-empty-list<Template\Provider\ProviderInterface>
-     */
-    private static function createTemplateProviders(IO\Messenger $messenger, Filesystem\Filesystem $filesystem): array
-    {
-        return [
-            new Template\Provider\PackagistProvider($messenger, $filesystem),
-            new Template\Provider\CustomComposerProvider($messenger, $filesystem),
-        ];
     }
 
     private static function runsOnAnUnsupportedEnvironment(): bool

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -49,7 +49,12 @@ final class Application
     private const ABORTED = 2;
 
     /**
-     * @param non-empty-list<Template\Provider\ProviderInterface> $templateProviders
+     * @var non-empty-list<Template\Provider\ProviderInterface>
+     */
+    private array $templateProviders;
+
+    /**
+     * @param list<Template\Provider\ProviderInterface> $templateProviders
      */
     public function __construct(
         private IO\Messenger $messenger,
@@ -57,8 +62,13 @@ final class Application
         private Error\ErrorHandler $errorHandler,
         private Filesystem\Filesystem $filesystem,
         private string $targetDirectory,
-        private array $templateProviders,
+        array $templateProviders = [],
     ) {
+        if ([] === $templateProviders) {
+            $templateProviders = $this->createDefaultTemplateProviders();
+        }
+
+        $this->templateProviders = $templateProviders;
     }
 
     public function run(): int
@@ -149,5 +159,16 @@ final class Application
         $container->set('app.messenger', $this->messenger);
 
         return $container;
+    }
+
+    /**
+     * @return non-empty-list<Template\Provider\ProviderInterface>
+     */
+    private function createDefaultTemplateProviders(): array
+    {
+        return [
+            new Template\Provider\PackagistProvider($this->messenger, $this->filesystem),
+            new Template\Provider\CustomComposerProvider($this->messenger, $this->filesystem),
+        ];
     }
 }

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/project-builder".
+ *
+ * Copyright (C) 2022 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\ProjectBuilder\Console;
+
+use CPSIT\ProjectBuilder\Builder;
+use CPSIT\ProjectBuilder\DependencyInjection;
+use CPSIT\ProjectBuilder\Error;
+use CPSIT\ProjectBuilder\Exception;
+use CPSIT\ProjectBuilder\IO;
+use CPSIT\ProjectBuilder\Paths;
+use CPSIT\ProjectBuilder\Resource;
+use CPSIT\ProjectBuilder\Template;
+use Symfony\Component\Filesystem;
+use Throwable;
+
+/**
+ * Application.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ *
+ * @internal
+ */
+final class Application
+{
+    private const SUCCESSFUL = 0;
+    private const FAILED = 1;
+    private const ABORTED = 2;
+
+    /**
+     * @param non-empty-list<Template\Provider\ProviderInterface> $templateProviders
+     */
+    public function __construct(
+        private IO\Messenger $messenger,
+        private Builder\Config\ConfigReader $configReader,
+        private Error\ErrorHandler $errorHandler,
+        private Filesystem\Filesystem $filesystem,
+        private string $targetDirectory,
+        private array $templateProviders,
+    ) {
+    }
+
+    public function run(): int
+    {
+        if (!$this->messenger->isInteractive()) {
+            $this->messenger->error('This command cannot be run in non-interactive mode.');
+
+            return self::FAILED;
+        }
+
+        $this->mirrorSourceFiles();
+
+        $loader = Resource\Local\Composer::createClassLoader();
+        $loader->register(true);
+
+        $this->messenger->clearScreen();
+        $this->messenger->welcome();
+
+        try {
+            // Select template source
+            $templateSource = $this->selectTemplateSource();
+            $templateSource->getProvider()->installTemplateSource($templateSource);
+            $templateIdentifier = $templateSource->getPackage()->getName();
+
+            // Create container
+            $config = $this->configReader->readConfig($templateIdentifier);
+            $container = $this->buildContainer($config);
+
+            // Run project generation
+            $generator = $container->get(Builder\Generator\Generator::class);
+            $result = $generator->run($this->targetDirectory);
+
+            // Show project generation result
+            $this->messenger->decorateResult($result);
+
+            // Early return if project generation was aborted
+            if (!$result->isMirrored()) {
+                return self::ABORTED;
+            }
+
+            $generator->cleanUp($result);
+        } catch (Throwable $exception) {
+            $this->errorHandler->handleException($exception);
+
+            return self::FAILED;
+        }
+
+        return self::SUCCESSFUL;
+    }
+
+    private function mirrorSourceFiles(): void
+    {
+        $this->filesystem->mirror(
+            Filesystem\Path::join($this->targetDirectory, Paths::PROJECT_SOURCES),
+            Filesystem\Path::join($this->targetDirectory, '.build', Paths::PROJECT_SOURCES),
+        );
+    }
+
+    /**
+     * @throws Exception\InvalidTemplateSourceException
+     */
+    private function selectTemplateSource(): Template\TemplateSource
+    {
+        try {
+            $templateProvider = $this->messenger->selectProvider($this->templateProviders);
+            $templateSource = $this->messenger->selectTemplateSource($templateProvider);
+        } catch (Exception\InvalidTemplateSourceException $exception) {
+            $retry = $this->messenger->confirmTemplateSourceRetry($exception);
+
+            $this->messenger->newLine();
+
+            if ($retry) {
+                return $this->selectTemplateSource();
+            }
+
+            throw $exception;
+        }
+
+        return $templateSource;
+    }
+
+    private function buildContainer(Builder\Config\Config $config): \Symfony\Component\DependencyInjection\ContainerInterface
+    {
+        $factory = DependencyInjection\ContainerFactory::createFromConfig($config);
+        $container = $factory->get();
+
+        $container->set('app.config', $config);
+        $container->set('app.messenger', $this->messenger);
+
+        return $container;
+    }
+}

--- a/src/Console/Simulation.php
+++ b/src/Console/Simulation.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/project-builder".
+ *
+ * Copyright (C) 2022 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\ProjectBuilder\Console;
+
+use Composer\Factory;
+use Composer\XdebugHandler;
+use CPSIT\ProjectBuilder\Helper;
+use CPSIT\ProjectBuilder\Resource;
+use Symfony\Component\Console;
+use Symfony\Component\Filesystem;
+use Symfony\Component\Finder;
+
+/**
+ * Simulation.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ *
+ * @internal
+ *
+ * @codeCoverageIgnore
+ */
+final class Simulation
+{
+    private Console\Style\SymfonyStyle $io;
+
+    private function __construct(
+        private Filesystem\Filesystem $filesystem,
+        private Resource\Local\Composer $composer,
+        private Console\Output\OutputInterface $output,
+        private string $rootPath,
+        private string $targetDirectory,
+    ) {
+        $this->io = new Console\Style\SymfonyStyle(new Console\Input\ArgvInput(), $this->output);
+    }
+
+    public static function create(): self
+    {
+        $filesystem = new Filesystem\Filesystem();
+        $rootPath = Helper\FilesystemHelper::getProjectRootPath();
+
+        return new self(
+            $filesystem,
+            new Resource\Local\Composer($filesystem),
+            Factory::createOutput(),
+            $rootPath,
+            Filesystem\Path::join($rootPath, '.build', uniqid('simulate_')),
+        );
+    }
+
+    public function prepare(): string
+    {
+        // Override current root path
+        putenv('PROJECT_BUILDER_ROOT_PATH='.$this->targetDirectory);
+
+        // Remove old simulations
+        $this->removeLegacySimulations();
+
+        // Mirror project files to the simulation directory and install
+        // Composer dependencies. This mimics the behavior of
+        // "composer create-project" installing the repository into the
+        // specified directory.
+        $this->mirrorProjectFiles();
+
+        // Disable Xdebug
+        XdebugHandler\Process::setEnv('COMPOSER_ALLOW_XDEBUG');
+
+        // Install project
+        $exitCode = $this->composer->install(
+            Filesystem\Path::join($this->targetDirectory, 'composer.json'),
+            true,
+            $this->output,
+        );
+
+        // Early exit if composer install fails
+        if ($exitCode > 0) {
+            $this->io->error(
+                sprintf('Unable to install project dependencies. Exit code: %d', $exitCode),
+            );
+
+            exit($exitCode);
+        }
+
+        return $this->targetDirectory;
+    }
+
+    /**
+     * @param callable(): int $applicationCode
+     */
+    public function run(callable $applicationCode): int
+    {
+        // Switch to simulation directory
+        $initialWorkingDirectory = false !== getcwd() ? getcwd() : Helper\FilesystemHelper::getProjectRootPath();
+        chdir($this->targetDirectory);
+
+        // Run project creation
+        $exitCode = $applicationCode();
+
+        // Go back to initial working directory
+        chdir($initialWorkingDirectory);
+
+        $message = sprintf('Simulation finished with exit code: %d', $exitCode);
+        if ($exitCode > 0) {
+            $this->io->error($message);
+        } else {
+            $this->io->success($message);
+        }
+        $this->io->writeln(
+            sprintf('Target directory: <comment>%s</comment>', $this->targetDirectory),
+        );
+
+        return $exitCode;
+    }
+
+    private function removeLegacySimulations(): void
+    {
+        $oldSimulations = Finder\Finder::create()
+            ->directories()
+            ->in(dirname($this->targetDirectory))
+            ->name('simulate_*')
+            ->depth('== 0')
+        ;
+
+        $this->filesystem->remove($oldSimulations);
+    }
+
+    private function mirrorProjectFiles(): void
+    {
+        $projectFiles = Finder\Finder::create()
+            ->in($this->rootPath)
+            ->notPath('.build')
+            ->notPath('vendor')
+            ->notName('composer.lock')
+        ;
+
+        $this->filesystem->mirror(dirname(__DIR__, 2), $this->targetDirectory, $projectFiles);
+    }
+}

--- a/tests/src/ClearableBufferIO.php
+++ b/tests/src/ClearableBufferIO.php
@@ -43,4 +43,15 @@ final class ClearableBufferIO extends IO\BufferIO
         fseek($this->output->getStream(), 0);
         fflush($this->output->getStream());
     }
+
+    public function makeInteractive(bool $interactive = true): self
+    {
+        if (null === $this->input->getStream()) {
+            $this->setUserInputs([]);
+        }
+
+        $this->input->setInteractive($interactive);
+
+        return $this;
+    }
 }

--- a/tests/src/Console/ApplicationTest.php
+++ b/tests/src/Console/ApplicationTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/project-builder".
+ *
+ * Copyright (C) 2022 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\ProjectBuilder\Tests\Console;
+
+use Composer\Package;
+use CPSIT\ProjectBuilder as Src;
+use CPSIT\ProjectBuilder\Tests;
+use Symfony\Component\Filesystem;
+
+use function dirname;
+use function sprintf;
+use function substr_count;
+
+/**
+ * ApplicationTest.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+final class ApplicationTest extends Tests\ContainerAwareTestCase
+{
+    private string $targetDirectory;
+    private Filesystem\Filesystem $filesystem;
+    private Src\Tests\Fixtures\DummyProvider $templateProvider;
+    private Src\Console\Application $subject;
+
+    protected function setUp(): void
+    {
+        $messenger = self::$container->get('app.messenger');
+
+        $this->targetDirectory = Src\Helper\FilesystemHelper::getNewTemporaryDirectory();
+        $this->filesystem = self::$container->get(Filesystem\Filesystem::class);
+        $this->templateProvider = new Src\Tests\Fixtures\DummyProvider();
+        $this->subject = new Src\Console\Application(
+            $messenger,
+            Src\Builder\Config\ConfigReader::create(dirname(__DIR__).'/Fixtures/Templates'),
+            new Src\Error\ErrorHandler($messenger),
+            $this->filesystem,
+            $this->targetDirectory,
+            [$this->templateProvider],
+        );
+
+        $this->filesystem->mirror(dirname(__DIR__, 2), $this->targetDirectory);
+
+        self::$io->makeInteractive();
+    }
+
+    /**
+     * @test
+     */
+    public function runThrowsExceptionIfInputIsNonInteractive(): void
+    {
+        self::$io->makeInteractive(false);
+
+        self::assertSame(1, $this->subject->run());
+
+        $output = self::$io->getOutput();
+
+        self::assertStringContainsString('This command cannot be run in non-interactive mode.', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function runMirrorsSourceFilesToTemporaryDirectory(): void
+    {
+        $temporaryDirectory = $this->targetDirectory.'/.build/src';
+
+        self::assertDirectoryDoesNotExist($temporaryDirectory);
+
+        self::$io->setUserInputs(['', 'no']);
+
+        $this->subject->run();
+
+        self::assertDirectoryExists($temporaryDirectory);
+    }
+
+    /**
+     * @test
+     */
+    public function runShowsWelcomeScreen(): void
+    {
+        self::$io->setUserInputs(['', 'no']);
+
+        $this->subject->run();
+
+        $output = self::$io->getOutput();
+
+        self::assertStringContainsString('Welcome to the CPS Project Builder', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function runAllowsSelectingADifferentTemplateProviderIfTheSelectedProviderProvidesNoTemplates(): void
+    {
+        self::$io->setUserInputs(['', 'yes', '', 'no']);
+
+        $this->subject->run();
+
+        $output = self::$io->getOutput();
+
+        self::assertStringContainsStringMultipleTimes(
+            'Which platform hosts the project template you want to create?',
+            $output,
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function runFailsIfProjectGenerationIsAborted(): void
+    {
+        $this->templateProvider->installationPath = $this->targetDirectory;
+        $this->templateProvider->templateSources = [
+            $this->createTemplateSource(),
+        ];
+
+        self::$io->setUserInputs(['', '', 'foo', 'no']);
+
+        self::assertSame(2, $this->subject->run());
+    }
+
+    /**
+     * @test
+     */
+    public function runHandlesErrorDuringProjectGeneration(): void
+    {
+        $this->templateProvider->installationPath = $this->targetDirectory;
+        $this->templateProvider->templateSources = [
+            $this->createTemplateSource(),
+        ];
+
+        self::$io->setUserInputs(['', '']);
+
+        self::assertSame(1, $this->subject->run());
+        self::assertStringContainsString(
+            'Running step "collectBuildInstructions" failed. All applied steps were reverted. [1652954290]',
+            self::$io->getOutput(),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function runGeneratesNewProjectFromSelectedTemplate(): void
+    {
+        $this->templateProvider->installationPath = $this->targetDirectory;
+        $this->templateProvider->templateSources = [
+            $this->createTemplateSource(),
+        ];
+
+        self::$io->setUserInputs(['', '', 'foo', 'yes']);
+
+        self::assertSame(0, $this->subject->run());
+        self::assertStringContainsString(
+            'Congratulations, your new project was successfully built!',
+            self::$io->getOutput(),
+        );
+    }
+
+    private function createTemplateSource(): Src\Template\TemplateSource
+    {
+        $sourcePath = dirname(__DIR__).'/Fixtures/Templates/json-template';
+        $package = Src\Resource\Local\Composer::createComposer($sourcePath)->getPackage();
+
+        self::assertInstanceOf(Package\Package::class, $package);
+
+        $package->setSourceUrl($sourcePath);
+
+        return new Src\Template\TemplateSource($this->templateProvider, $package);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->filesystem->remove($this->targetDirectory);
+    }
+
+    private static function assertStringContainsStringMultipleTimes(string $needle, string $haystack): void
+    {
+        self::assertGreaterThan(
+            1,
+            substr_count($haystack, $needle),
+            sprintf('Failed asserting that "%s" contains "%s" multiple times', $haystack, $needle),
+        );
+    }
+}

--- a/tests/src/ContainerAwareTestCase.php
+++ b/tests/src/ContainerAwareTestCase.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 namespace CPSIT\ProjectBuilder\Tests;
 
-use Composer\IO;
 use CPSIT\ProjectBuilder as Src;
 use GuzzleHttp\Handler;
 use GuzzleHttp\HandlerStack;
@@ -44,7 +43,7 @@ abstract class ContainerAwareTestCase extends TestCase
 {
     protected static DependencyInjection\ContainerInterface $container;
     protected static Factory\HttplugFactory $factory;
-    protected static IO\BufferIO $io;
+    protected static ClearableBufferIO $io;
     protected static Handler\MockHandler $mockHandler;
     protected static Src\Builder\Config\Config $config;
 
@@ -90,7 +89,7 @@ abstract class ContainerAwareTestCase extends TestCase
         return $config;
     }
 
-    protected static function createIO(): IO\BufferIO
+    protected static function createIO(): ClearableBufferIO
     {
         return new ClearableBufferIO();
     }
@@ -124,8 +123,6 @@ abstract class ContainerAwareTestCase extends TestCase
 
     protected function tearDown(): void
     {
-        if (self::$io instanceof ClearableBufferIO) {
-            self::$io->clear();
-        }
+        self::$io->clear();
     }
 }


### PR DESCRIPTION
With this PR, the actual application logic is decoupled from the bootstrapping component. This makes it possible to better test the application logic in an isolated scope, separating it from the actual environment construction which is already available in testing context.

Additionally, the application simulation logic is moved to a separate class.