### PR TITLE
[TASK] Include Composer 2.5 in test matrix

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         php-version: ["8.0", "8.1", "8.2"]
-        composer-version: ["2.1", "2.2", "2.3", "2.4"]
+        composer-version: ["2.1", "2.2", "2.3", "2.4", "2.5"]
         dependencies: ["highest", "lowest"]
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Composer 2.5 was released and we should continuously test its compatibility with the project builder. Therefore, it is now included in the test matrix.