### PR TITLE
[BUGFIX] Use Dependabot's automatic versioning strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,4 +23,3 @@ updates:
     labels:
       - dependencies
     open-pull-requests-limit: 10
-    versioning-strategy: widen


### PR DESCRIPTION
We can safely use Dependabot's automatic versioning strategy for Composer, since the test workflow already tests for compatibility with supported environments.