### PR TITLE
[BUGFIX] Properly handle latest version constraint

### DIFF
--- a/installer/composer.json.twig
+++ b/installer/composer.json.twig
@@ -7,7 +7,7 @@
 		"composer/installers": "^2.0",
 		"oomphinc/composer-installers-extender": "^2.0",
 {% for templateSource in templateSources %}
-		"{{ templateSource.package.name }}": "{{ templateSource.package.prettyVersion }}"
+		"{{ templateSource.package.name }}": "{% if templateSource.shouldUseDynamicVersionConstraint %}*{% else %}{{ templateSource.package.prettyVersion }}{% endif %}"
 {% endfor %}
 	},
 	"repositories": [

--- a/src/Template/Provider/BaseComposerProvider.php
+++ b/src/Template/Provider/BaseComposerProvider.php
@@ -116,7 +116,12 @@ abstract class BaseComposerProvider implements ProviderInterface
         $output = new Console\Output\BufferedOutput();
 
         $this->messenger->progress(
-            sprintf('Installing template source (<info>%s</info>)...', $templateSource->getPackage()->getPrettyVersion()),
+            sprintf(
+                'Installing template source%s...',
+                $templateSource->shouldUseDynamicVersionConstraint()
+                    ? ''
+                    : sprintf(' (<info>%s</info>)', $templateSource->getPackage()->getPrettyVersion()),
+            ),
             ComposerIO\IOInterface::NORMAL,
         );
 
@@ -153,7 +158,9 @@ abstract class BaseComposerProvider implements ProviderInterface
         $this->messenger->newLine();
 
         if (null === $constraint) {
-            $constraint = '*';
+            $templateSource->useDynamicVersionConstraint();
+
+            return;
         }
 
         $package = $repository->findPackage($templateSource->getPackage()->getName(), $constraint);

--- a/src/Template/TemplateSource.php
+++ b/src/Template/TemplateSource.php
@@ -33,6 +33,8 @@ use Composer\Package;
  */
 final class TemplateSource
 {
+    private bool $dynamicVersionConstraint = false;
+
     public function __construct(
         private Provider\ProviderInterface $provider,
         private Package\PackageInterface $package,
@@ -52,6 +54,18 @@ final class TemplateSource
     public function setPackage(Package\PackageInterface $package): self
     {
         $this->package = $package;
+
+        return $this;
+    }
+
+    public function shouldUseDynamicVersionConstraint(): bool
+    {
+        return $this->dynamicVersionConstraint;
+    }
+
+    public function useDynamicVersionConstraint(bool $dynamicVersionConstraint = true): self
+    {
+        $this->dynamicVersionConstraint = $dynamicVersionConstraint;
 
         return $this;
     }

--- a/tests/src/Template/Provider/BaseComposerProviderTest.php
+++ b/tests/src/Template/Provider/BaseComposerProviderTest.php
@@ -129,6 +129,27 @@ final class BaseComposerProviderTest extends Tests\ContainerAwareTestCase
     /**
      * @test
      */
+    public function installTemplateSourceFailsIfGivenConstraintIsInvalid(): void
+    {
+        $package = $this->createPackageFromTemplateFixture();
+        $templateSource = new Template\TemplateSource($this->subject, $package);
+
+        $this->subject->packages = [$package];
+
+        $this->mockPackagesServerResponse([$package]);
+
+        self::$io->setUserInputs(['^2.0', 'no']);
+
+        $this->expectExceptionObject(
+            Exception\InvalidTemplateSourceException::forInvalidPackageVersionConstraint($templateSource, '^2.0'),
+        );
+
+        $this->subject->installTemplateSource($templateSource);
+    }
+
+    /**
+     * @test
+     */
     public function installTemplateSourceAllowsSpecifyingOtherConstraintIfInstallationFailsWithGivenConstraint(): void
     {
         $package = $this->createPackageFromTemplateFixture();

--- a/tests/src/Template/TemplateSourceTest.php
+++ b/tests/src/Template/TemplateSourceTest.php
@@ -26,6 +26,7 @@ namespace CPSIT\ProjectBuilder\Tests\Template;
 use Composer\Package;
 use CPSIT\ProjectBuilder as Src;
 use CPSIT\ProjectBuilder\Tests;
+use Generator;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -61,5 +62,46 @@ final class TemplateSourceTest extends TestCase
     public function getPackageReturnsPackage(): void
     {
         self::assertSame($this->package, $this->subject->getPackage());
+    }
+
+    /**
+     * @test
+     */
+    public function setPackageAppliesGivenPackage(): void
+    {
+        $newPackage = clone $this->package;
+
+        self::assertSame($newPackage, $this->subject->setPackage($newPackage)->getPackage());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldUseDynamicVersionConstraintReturnsFalseInitially(): void
+    {
+        self::assertFalse($this->subject->shouldUseDynamicVersionConstraint());
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider useDynamicVersionConstraintDefinesWhetherToUseDynamicVersionConstraintDataProvider
+     */
+    public function useDynamicVersionConstraintDefinesWhetherToUseDynamicVersionConstraint(
+        bool $useDynamicVersionConstraint,
+        bool $expected,
+    ): void {
+        $this->subject->useDynamicVersionConstraint($useDynamicVersionConstraint);
+
+        self::assertSame($expected, $this->subject->shouldUseDynamicVersionConstraint());
+    }
+
+    /**
+     * @return Generator<string, array{bool, bool}>
+     */
+    public function useDynamicVersionConstraintDefinesWhetherToUseDynamicVersionConstraintDataProvider(): Generator
+    {
+        yield 'true' => [true, true];
+        yield 'false' => [false, false];
     }
 }


### PR DESCRIPTION
With #61, usage of template package version constraints was introduced. However, if one omits specifying a custom version constraint, the default constraint (= latest version) is not always properly applied, e.g. if the requested package is already cached globally by Composer. This PR assures the expected behavior.