### PR TITLE
[BUGFIX] Allow using constraints with minimum stability "dev"

### DIFF
--- a/installer/composer.json.twig
+++ b/installer/composer.json.twig
@@ -16,6 +16,8 @@
 			"url": "{{ providerUrl }}"
 		}
 	],
+	"minimum-stability": "dev",
+	"prefer-stable": true,
 	"config": {
 		"allow-plugins": {
 			"composer/installers": true,


### PR DESCRIPTION
Since #61, a custom constraint can be configured during template installation. However, this is not fully supported for constraints with stability lower than "stable", e.g. branches or RCs. This PR defines a minimum-stability "dev" along with installation preference "stable" to solve this issue.