### PR TITLE
[BUGFIX] Avoid errors when accessing skipped properties

### DIFF
--- a/src/Builder/Generator/Step/CollectBuildInstructionsStep.php
+++ b/src/Builder/Generator/Step/CollectBuildInstructionsStep.php
@@ -52,6 +52,10 @@ final class CollectBuildInstructionsStep extends AbstractStep
 
         foreach ($instructions->getConfig()->getProperties() as $property) {
             if (!$property->conditionMatches($this->expressionLanguage, $instructions->getTemplateVariables(), true)) {
+                // Apply NULL as value of property to avoid errors in conditions
+                // that reference this property in array-notation
+                $this->apply($property->getPath(), null, $buildResult);
+
                 continue;
             }
 
@@ -101,6 +105,10 @@ final class CollectBuildInstructionsStep extends AbstractStep
         $instructions = $buildResult->getInstructions();
 
         if (!$subProperty->conditionMatches($this->expressionLanguage, $instructions->getTemplateVariables(), true)) {
+            // Apply NULL as value of sub-property to avoid errors in conditions
+            // that reference this sub-property in array-notation
+            $this->apply($subProperty->getPath(), null, $buildResult);
+
             return;
         }
 

--- a/tests/src/Builder/Generator/Step/CollectBuildInstructionsStepTest.php
+++ b/tests/src/Builder/Generator/Step/CollectBuildInstructionsStepTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/project-builder".
+ *
+ * Copyright (C) 2023 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\ProjectBuilder\Tests\Builder\Generator\Step;
+
+use CPSIT\ProjectBuilder as Src;
+use CPSIT\ProjectBuilder\Tests;
+
+/**
+ * CollectBuildInstructionsStepTest.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+final class CollectBuildInstructionsStepTest extends Tests\ContainerAwareTestCase
+{
+    private Src\Builder\Generator\Step\CollectBuildInstructionsStep $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = self::$container->get(Src\Builder\Generator\Step\CollectBuildInstructionsStep::class);
+    }
+
+    /**
+     * @test
+     */
+    public function runAppliesNullAsDefaultValueOnSkippedProperties(): void
+    {
+        $config = new Src\Builder\Config\Config(
+            'test',
+            'Test',
+            [
+                new Src\Builder\Config\ValueObject\Step('dummy'),
+            ],
+            [
+                new Src\Builder\Config\ValueObject\Property(
+                    'foo',
+                    'Foo',
+                    null,
+                    'false',
+                    'baz',
+                ),
+            ],
+        );
+        $config->setDeclaringFile(__FILE__);
+
+        $buildResult = new Src\Builder\BuildResult(
+            new Src\Builder\BuildInstructions($config, 'foo'),
+        );
+
+        $this->subject->run($buildResult);
+
+        self::assertNull($buildResult->getInstructions()->getTemplateVariable('foo'));
+    }
+
+    /**
+     * @test
+     */
+    public function runAppliesNullAsDefaultValueOnSkippedSubProperties(): void
+    {
+        $config = new Src\Builder\Config\Config(
+            'test',
+            'Test',
+            [
+                new Src\Builder\Config\ValueObject\Step('dummy'),
+            ],
+            [
+                new Src\Builder\Config\ValueObject\Property(
+                    'foo',
+                    'Foo',
+                    null,
+                    null,
+                    null,
+                    [
+                        new Src\Builder\Config\ValueObject\SubProperty(
+                            'bar',
+                            'Bar',
+                            'staticValue',
+                            null,
+                            'false',
+                        ),
+                    ],
+                ),
+            ],
+        );
+        $config->setDeclaringFile(__FILE__);
+
+        $buildResult = new Src\Builder\BuildResult(
+            new Src\Builder\BuildInstructions($config, 'foo'),
+        );
+
+        $this->subject->run($buildResult);
+
+        self::assertSame(['bar' => null], $buildResult->getInstructions()->getTemplateVariable('foo'));
+        self::assertNull($buildResult->getInstructions()->getTemplateVariable('foo/bar'));
+    }
+}


### PR DESCRIPTION
When properties or sub-properties are skipped (that is, a configured `if` condition evaluates to `false`), they can no longer be referenced in other conditions. That leads to an error when accessing those properties:

> Undefined array key "xyz"

As a result, the whole project generation process fails.

To circumvent this behavior, `null` is now always used as default value in case the property or sub-property was skipped.