### PR TITLE
[BUGFIX] Properly reset IO between test cases

### DIFF
--- a/tests/src/ContainerAwareTestCase.php
+++ b/tests/src/ContainerAwareTestCase.php
@@ -123,6 +123,6 @@ abstract class ContainerAwareTestCase extends TestCase
 
     protected function tearDown(): void
     {
-        self::$io->clear();
+        self::$io->reset();
     }
 }


### PR DESCRIPTION
The IO was never completely reset between test cases. Instead, only the output stream was cleared. With this PR, both input and output streams are now correctly re-initialized with their initial state.