### PR TITLE
[TASK] Validate JSON schema in CGL workflow

### DIFF
--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -59,3 +59,7 @@ jobs:
       # Migration
       - name: Rector migration
         run: composer migration:rector -- --dry-run
+
+      # Schema
+      - name: Validate JSON schema
+        run: composer validate-schema

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,12 @@ last HTML report like follows:
 open .build/coverage/html/index.html
 ```
 
+## Validate JSON schema
+
+```bash
+composer validate-schema
+```
+
 ## Simulate `composer create-project` behavior
 
 The `composer create-project` behavior can be simulated to test whether the

--- a/composer.json
+++ b/composer.json
@@ -106,6 +106,7 @@
 			"CPSIT\\ProjectBuilder\\Bootstrap::simulateCreateProject"
 		],
 		"test": "phpunit -c phpunit.xml",
-		"test:coverage": "phpunit -c phpunit.coverage.xml"
+		"test:coverage": "phpunit -c phpunit.coverage.xml",
+		"validate-schema": "docker run --rm -v \"$(pwd)\":/code swaggest/json-cli json-cli validate-schema resources/config.schema.json"
 	}
 }


### PR DESCRIPTION
This PR introduces a new Composer script `validate-schema`. It can be used to validate the configured JSON schema and is already added to the CGL workflow.