### PR TITLE
[FEATURE] Allow specifying project builder as dependency in template packages

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,12 +26,28 @@ three ways to make a template package available to the project builder:
 
 1. Either register it on [Packagist](https://packagist.org/),
 2. Use any other Composer registry (e.g. self-hosted [Satis][4] instance),
-or
-3. Host the project template on a VCS repository (such as GitHub) to make your package
-available to the project builder.
+   or
+3. Host the project template on a VCS repository (such as GitHub) to make
+   your package available to the project builder.
 
 Once you use the project builder to create a new project, you can
 select the appropriate provider that hosts your template package.
+
+:bulb: You can add the `cpsit/project-builder` package as dependency to
+your template package and Composer will correctly resolve the constraint.
+This way you can define which versions of the project builder are actually
+supported by your package:
+
+```diff
+ {
+     "name": "cpsit/project-builder-template-my-fancy-project",
+     "type": "project-builder-template",
++    "require": {
++        "cpsit/project-builder": "^1.0"
++    }
+     // ...
+ }
+```
 
 ## Structure
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,9 +33,9 @@ three ways to make a template package available to the project builder:
 Once you use the project builder to create a new project, you can
 select the appropriate provider that hosts your template package.
 
-:bulb: You can add the `cpsit/project-builder` package as dependency to
-your template package and Composer will correctly resolve the constraint.
-This way you can define which versions of the project builder are actually
+:bulb: You can add the `cpsit/project-builder` package as a dependency to
+your template package. Composer will correctly resolve the constraint.
+This way, you can define the versions of the project builder actually
 supported by your package:
 
 ```diff

--- a/installer/composer.json.twig
+++ b/installer/composer.json.twig
@@ -10,6 +10,9 @@
 		"{{ templateSource.package.name }}": "{% if templateSource.shouldUseDynamicVersionConstraint %}*{% else %}{{ templateSource.package.prettyVersion }}{% endif %}"
 {% endfor %}
 	},
+	"replace": {
+		"cpsit/project-builder": "self.version"
+	},
 	"repositories": [
 {% for repository in repositories %}
 		{


### PR DESCRIPTION
Template packages may now define version constraints for compatible versions of the project builder in their `composer.json`:

```diff
 {
     "name": "cpsit/project-builder-template-my-fancy-project",
     "type": "project-builder-template",
+    "require": {
+        "cpsit/project-builder": "^1.0"
+    }
     // ...
 }
```

The `cpsit/project-builder` dependency is replaced during installation of the template package, thus no additional vendor files will be downloaded. Instead, Composer is now able to better distinguish between compatible versions of the project builder and requested template packages.