### PR TITLE
[BUGFIX] Allow simulation of root package version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,11 @@ into a simulated directory, which is normally something like
 `.build/simulate_6299c0dda8600`. The simulated directory will be shown after
 simulation has finished.
 
+:bulb: An environment variable `PROJECT_BUILDER_SIMULATE_VERSION` can be used
+to override the project builder version during simulation. This is especially
+useful when testing template packages that require a specific version of the
+project builder.
+
 ## Submit a pull request
 
 Once you have finished your work, please **submit a pull request** and describe

--- a/installer/composer.json.twig
+++ b/installer/composer.json.twig
@@ -11,7 +11,7 @@
 {% endfor %}
 	},
 	"replace": {
-		"cpsit/project-builder": "self.version"
+		"cpsit/project-builder": "{% if simulatedRootPackageVersion %}{{ simulatedRootPackageVersion }}{% else %}self.version{% endif %}"
 	},
 	"repositories": [
 {% for repository in repositories %}

--- a/src/Template/Provider/BaseProvider.php
+++ b/src/Template/Provider/BaseProvider.php
@@ -39,6 +39,7 @@ use Symfony\Component\Filesystem;
 use Twig\Environment;
 use Twig\Loader;
 
+use function getenv;
 use function sprintf;
 
 /**
@@ -208,6 +209,7 @@ abstract class BaseProvider implements ProviderInterface
             'tempDir' => $targetDirectory,
             'repositories' => $repositories,
             'acceptInsecureConnections' => $this->acceptInsecureConnections,
+            'simulatedRootPackageVersion' => getenv('PROJECT_BUILDER_SIMULATE_VERSION'),
         ]);
 
         $this->filesystem->dumpFile($targetFile, $composerJson);


### PR DESCRIPTION
This PR fixes a possible side effect introduced with #78 that may occur during development of this package or subsequent template packages. When working in a specific development branch, the current package version is hidden which causes template package installations to fail, especially when running `composer simulate`.

With this PR, a new environment variable `PROJECT_BUILDER_SIMULATE_VERSION` is introduced. It can be used to explicitly override the current root package version.

Example:

```bash
PROJECT_BUILDER_SIMULATE_VERSION=1.5.0 composer simulate -v
```

Resolves: #80