### PR TITLE
[TASK] Exclude several files from dist archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 *                         text=auto
 /.github                  export-ignore
 /tests                    export-ignore
+/.editorconfig            export-ignore
 /.gitattributes           export-ignore
 /.gitignore               export-ignore
 /.php-cs-fixer.php        export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,7 @@
 /.php-cs-fixer.php        export-ignore
 /codecov.yml              export-ignore
 /composer.lock            export-ignore
+/CONTRIBUTING.md          export-ignore
 /dependency-checker.json  export-ignore
 /docker-entrypoint.sh     export-ignore
 /Dockerfile               export-ignore


### PR DESCRIPTION
Both `.editorconfig` and `CONTRIBUTING.md` are not relevant in dist archives. Therefore, they're now added to `.gitattributes`.