### PR TITLE
[FEATURE] Validate package version constraint

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -162,6 +162,7 @@ As an additional I/O component, some **validators** exist, ready to be used by t
 
 | Type       | Class                                                            | Description                                          |
 |------------|------------------------------------------------------------------|------------------------------------------------------|
+| `callback` | [`CallbackValidator`](../src/IO/Validator/CallbackValidator.php) | User input is validated by a given callback          |
 | `email`    | [`EmailValidator`](../src/IO/Validator/EmailValidator.php)       | User input must be a valid e-mail address            |
 | `notEmpty` | [`NotEmptyValidator`](../src/IO/Validator/NotEmptyValidator.php) | User input must not be empty (strict mode available) |
 | `url`      | [`UrlValidator`](../src/IO/Validator/UrlValidator.php)           | User input must be a valid URL                       |

--- a/src/Exception/MisconfiguredValidatorException.php
+++ b/src/Exception/MisconfiguredValidatorException.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/project-builder".
+ *
+ * Copyright (C) 2023 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\ProjectBuilder\Exception;
+
+use CPSIT\ProjectBuilder\IO;
+use Exception;
+
+use function sprintf;
+
+/**
+ * MisconfiguredValidatorException.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+final class MisconfiguredValidatorException extends Exception
+{
+    public static function forUnexpectedOption(
+        string|IO\Validator\ValidatorInterface $validator,
+        string $option,
+    ): self {
+        if ($validator instanceof IO\Validator\ValidatorInterface) {
+            $validator = $validator::getType();
+        }
+
+        return new self(
+            sprintf('The validator option "%s" of validator "%s" is invalid.', $option, $validator),
+            1673886742,
+        );
+    }
+}

--- a/src/IO/Validator/AbstractValidator.php
+++ b/src/IO/Validator/AbstractValidator.php
@@ -28,6 +28,8 @@ namespace CPSIT\ProjectBuilder\IO\Validator;
  *
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-3.0-or-later
+ *
+ * @template T of array<string, mixed>
  */
 abstract class AbstractValidator implements ValidatorInterface
 {
@@ -37,7 +39,7 @@ abstract class AbstractValidator implements ValidatorInterface
     protected static array $defaultOptions = [];
 
     /**
-     * @var array<string, mixed>
+     * @phpstan-var T
      */
     protected array $options;
 

--- a/src/IO/Validator/CallbackValidator.php
+++ b/src/IO/Validator/CallbackValidator.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/project-builder".
+ *
+ * Copyright (C) 2023 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\ProjectBuilder\IO\Validator;
+
+use CPSIT\ProjectBuilder\Exception;
+
+use function is_callable;
+
+/**
+ * CallbackValidator.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ *
+ * @extends AbstractValidator<array{callback: callable(string|null): (string|null)}>
+ */
+final class CallbackValidator extends AbstractValidator
+{
+    private const TYPE = 'callback';
+
+    protected static array $defaultOptions = [
+        'callback' => null,
+    ];
+
+    /**
+     * @param array{callback?: callable(string|null): (string|null)} $options
+     *
+     * @throws Exception\MisconfiguredValidatorException
+     */
+    public function __construct(array $options = [])
+    {
+        if (!is_callable($options['callback'] ?? null)) {
+            throw Exception\MisconfiguredValidatorException::forUnexpectedOption($this, 'callback');
+        }
+
+        parent::__construct($options);
+    }
+
+    public function __invoke(?string $input): ?string
+    {
+        return $this->options['callback']($input);
+    }
+
+    public static function getType(): string
+    {
+        return self::TYPE;
+    }
+
+    public static function supports(string $type): bool
+    {
+        return self::TYPE === $type;
+    }
+}

--- a/src/IO/Validator/EmailValidator.php
+++ b/src/IO/Validator/EmailValidator.php
@@ -30,6 +30,8 @@ use CPSIT\ProjectBuilder\Exception;
  *
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-3.0-or-later
+ *
+ * @extends AbstractValidator<array{}>
  */
 final class EmailValidator extends AbstractValidator
 {

--- a/src/IO/Validator/NotEmptyValidator.php
+++ b/src/IO/Validator/NotEmptyValidator.php
@@ -30,6 +30,8 @@ use CPSIT\ProjectBuilder\Exception;
  *
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-3.0-or-later
+ *
+ * @extends AbstractValidator<array{strict: bool}>
  */
 final class NotEmptyValidator extends AbstractValidator
 {
@@ -64,6 +66,7 @@ final class NotEmptyValidator extends AbstractValidator
 
     private function isStrictCheckEnabled(): bool
     {
+        /* @phpstan-ignore-next-line */
         return (bool) $this->options['strict'];
     }
 }

--- a/src/IO/Validator/UrlValidator.php
+++ b/src/IO/Validator/UrlValidator.php
@@ -30,6 +30,8 @@ use CPSIT\ProjectBuilder\Exception;
  *
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-3.0-or-later
+ *
+ * @extends AbstractValidator<array{}>
  */
 final class UrlValidator extends AbstractValidator
 {

--- a/tests/src/Builder/Config/ValueObject/FileConditionTest.php
+++ b/tests/src/Builder/Config/ValueObject/FileConditionTest.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace CPSIT\ProjectBuilder\Tests\Builder\Config\ValueObject;
 
-use CPSIT\ProjectBuilder\Builder as Src;
+use CPSIT\ProjectBuilder as Src;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\ExpressionLanguage;
 
@@ -35,11 +35,11 @@ use Symfony\Component\ExpressionLanguage;
  */
 final class FileConditionTest extends TestCase
 {
-    private Src\Config\ValueObject\FileCondition $subject;
+    private Src\Builder\Config\ValueObject\FileCondition $subject;
 
     protected function setUp(): void
     {
-        $this->subject = new Src\Config\ValueObject\FileCondition('foo', 'bar', 'target');
+        $this->subject = new Src\Builder\Config\ValueObject\FileCondition('foo', 'bar', 'target');
     }
 
     /**

--- a/tests/src/Builder/Config/ValueObject/PropertyOptionTest.php
+++ b/tests/src/Builder/Config/ValueObject/PropertyOptionTest.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace CPSIT\ProjectBuilder\Tests\Builder\Config\ValueObject;
 
-use CPSIT\ProjectBuilder\Builder as Src;
+use CPSIT\ProjectBuilder as Src;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\ExpressionLanguage;
 
@@ -35,11 +35,11 @@ use Symfony\Component\ExpressionLanguage;
  */
 final class PropertyOptionTest extends TestCase
 {
-    private Src\Config\ValueObject\PropertyOption $subject;
+    private Src\Builder\Config\ValueObject\PropertyOption $subject;
 
     protected function setUp(): void
     {
-        $this->subject = new Src\Config\ValueObject\PropertyOption('foo', 'bar');
+        $this->subject = new Src\Builder\Config\ValueObject\PropertyOption('foo', 'bar');
     }
 
     /**
@@ -56,7 +56,7 @@ final class PropertyOptionTest extends TestCase
     public function conditionMatchesReturnsDefaultIfNoConditionIsSet(): void
     {
         $expressionLanguage = new ExpressionLanguage\ExpressionLanguage();
-        $subject = new Src\Config\ValueObject\PropertyOption('foo');
+        $subject = new Src\Builder\Config\ValueObject\PropertyOption('foo');
 
         self::assertTrue($subject->conditionMatches($expressionLanguage, [], true));
     }

--- a/tests/src/Builder/Config/ValueObject/PropertyValidatorTest.php
+++ b/tests/src/Builder/Config/ValueObject/PropertyValidatorTest.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace CPSIT\ProjectBuilder\Tests\Builder\Config\ValueObject;
 
-use CPSIT\ProjectBuilder\Builder as Src;
+use CPSIT\ProjectBuilder as Src;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -34,11 +34,11 @@ use PHPUnit\Framework\TestCase;
  */
 final class PropertyValidatorTest extends TestCase
 {
-    private Src\Config\ValueObject\PropertyValidator $subject;
+    private Src\Builder\Config\ValueObject\PropertyValidator $subject;
 
     protected function setUp(): void
     {
-        $this->subject = new Src\Config\ValueObject\PropertyValidator('foo', ['bar' => 'bar']);
+        $this->subject = new Src\Builder\Config\ValueObject\PropertyValidator('foo', ['bar' => 'bar']);
     }
 
     /**

--- a/tests/src/Fixtures/ModifyingValidator.php
+++ b/tests/src/Fixtures/ModifyingValidator.php
@@ -33,6 +33,8 @@ use function strtoupper;
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-3.0-or-later
  *
+ * @extends IO\Validator\AbstractValidator<array{}>
+ *
  * @internal
  */
 final class ModifyingValidator extends IO\Validator\AbstractValidator

--- a/tests/src/IO/Validator/CallbackValidatorTest.php
+++ b/tests/src/IO/Validator/CallbackValidatorTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/project-builder".
+ *
+ * Copyright (C) 2023 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\ProjectBuilder\Tests\IO\Validator;
+
+use CPSIT\ProjectBuilder as Src;
+use Generator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * CallbackValidatorTest.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+final class CallbackValidatorTest extends TestCase
+{
+    private Src\IO\Validator\CallbackValidator $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new Src\IO\Validator\CallbackValidator(['callback' => [$this, 'validate']]);
+    }
+
+    /**
+     * @test
+     */
+    public function constructorThrowsExceptionIfNoCallbackIsGiven(): void
+    {
+        $this->expectExceptionObject(
+            Src\Exception\MisconfiguredValidatorException::forUnexpectedOption($this->subject, 'callback'),
+        );
+
+        new Src\IO\Validator\CallbackValidator();
+    }
+
+    /**
+     * @test
+     */
+    public function constructorThrowsExceptionIfInvalidCallbackIsGiven(): void
+    {
+        $this->expectExceptionObject(
+            Src\Exception\MisconfiguredValidatorException::forUnexpectedOption($this->subject, 'callback'),
+        );
+
+        /* @phpstan-ignore-next-line */
+        new Src\IO\Validator\CallbackValidator(['callback' => 'foo']);
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider invokeCallsConfiguredCallbackDataProvider
+     */
+    public function invokeCallsConfiguredCallback(?string $input, ?string $expected): void
+    {
+        $actual = ($this->subject)($input);
+
+        self::assertSame($expected, $actual);
+    }
+
+    /**
+     * @return Generator<string, array{string|null, string|null}>
+     */
+    public function invokeCallsConfiguredCallbackDataProvider(): Generator
+    {
+        yield 'null' => [null, null];
+        yield 'string' => ['string', 'input is string'];
+    }
+
+    public function validate(?string $input): ?string
+    {
+        if (null === $input) {
+            return null;
+        }
+
+        return 'input is '.$input;
+    }
+}

--- a/tests/src/Template/Provider/BaseProviderTest.php
+++ b/tests/src/Template/Provider/BaseProviderTest.php
@@ -129,7 +129,29 @@ final class BaseProviderTest extends Tests\ContainerAwareTestCase
     /**
      * @test
      */
-    public function installTemplateSourceFailsIfGivenConstraintIsInvalid(): void
+    public function installTemplateSourceFailsSoftlyIfGivenConstraintIsInvalid(): void
+    {
+        $package = $this->createPackageFromTemplateFixture();
+        $templateSource = new Template\TemplateSource($this->subject, $package);
+
+        $this->subject->packages = [$package];
+
+        $this->mockPackagesServerResponse([$package]);
+
+        self::$io->setUserInputs(['foo', '']);
+
+        $this->subject->installTemplateSource($templateSource);
+
+        self::assertStringContainsString(
+            'Could not parse version constraint foo: Invalid version string "foo"',
+            self::$io->getOutput(),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function installTemplateSourceFailsIfGivenConstraintCannotBeResolved(): void
     {
         $package = $this->createPackageFromTemplateFixture();
         $templateSource = new Template\TemplateSource($this->subject, $package);

--- a/tests/src/Template/Provider/BaseProviderTest.php
+++ b/tests/src/Template/Provider/BaseProviderTest.php
@@ -27,9 +27,7 @@ use Composer\Package;
 use Composer\Repository;
 use Composer\Semver\Constraint;
 use Composer\Semver\VersionParser;
-use CPSIT\ProjectBuilder\Exception;
-use CPSIT\ProjectBuilder\Resource;
-use CPSIT\ProjectBuilder\Template;
+use CPSIT\ProjectBuilder as Src;
 use CPSIT\ProjectBuilder\Tests;
 use donatj\MockWebServer;
 use Generator;
@@ -78,7 +76,7 @@ final class BaseProviderTest extends Tests\ContainerAwareTestCase
         $this->subject->packages = $packages;
 
         $expectedTemplateSources = array_map(
-            fn (Package\PackageInterface $package) => new Template\TemplateSource($this->subject, $package),
+            fn (Package\PackageInterface $package) => new Src\Template\TemplateSource($this->subject, $package),
             $expected,
         );
 
@@ -100,13 +98,13 @@ final class BaseProviderTest extends Tests\ContainerAwareTestCase
                 '1.0.0',
             ),
         ]);
-        $templateSource = new Template\TemplateSource($this->subject, $package);
+        $templateSource = new Src\Template\TemplateSource($this->subject, $package);
 
         $this->subject->packages = [$package];
 
         $this->mockPackagesServerResponse([$package]);
 
-        $this->expectExceptionObject(Exception\InvalidTemplateSourceException::forFailedInstallation($templateSource));
+        $this->expectExceptionObject(Src\Exception\InvalidTemplateSourceException::forFailedInstallation($templateSource));
 
         $this->subject->installTemplateSource($templateSource);
     }
@@ -117,11 +115,11 @@ final class BaseProviderTest extends Tests\ContainerAwareTestCase
     public function installTemplateSourceThrowsExceptionIfInstallationFailsWithGivenConstraint(): void
     {
         $package = $this->createPackage('foo/baz');
-        $templateSource = new Template\TemplateSource($this->subject, $package);
+        $templateSource = new Src\Template\TemplateSource($this->subject, $package);
 
         self::$io->setUserInputs(['']);
 
-        $this->expectExceptionObject(Exception\InvalidTemplateSourceException::forFailedInstallation($templateSource));
+        $this->expectExceptionObject(Src\Exception\InvalidTemplateSourceException::forFailedInstallation($templateSource));
 
         $this->subject->installTemplateSource($templateSource);
     }
@@ -132,7 +130,7 @@ final class BaseProviderTest extends Tests\ContainerAwareTestCase
     public function installTemplateSourceFailsSoftlyIfGivenConstraintIsInvalid(): void
     {
         $package = $this->createPackageFromTemplateFixture();
-        $templateSource = new Template\TemplateSource($this->subject, $package);
+        $templateSource = new Src\Template\TemplateSource($this->subject, $package);
 
         $this->subject->packages = [$package];
 
@@ -154,7 +152,7 @@ final class BaseProviderTest extends Tests\ContainerAwareTestCase
     public function installTemplateSourceFailsIfGivenConstraintCannotBeResolved(): void
     {
         $package = $this->createPackageFromTemplateFixture();
-        $templateSource = new Template\TemplateSource($this->subject, $package);
+        $templateSource = new Src\Template\TemplateSource($this->subject, $package);
 
         $this->subject->packages = [$package];
 
@@ -163,7 +161,7 @@ final class BaseProviderTest extends Tests\ContainerAwareTestCase
         self::$io->setUserInputs(['^2.0', 'no']);
 
         $this->expectExceptionObject(
-            Exception\InvalidTemplateSourceException::forInvalidPackageVersionConstraint($templateSource, '^2.0'),
+            Src\Exception\InvalidTemplateSourceException::forInvalidPackageVersionConstraint($templateSource, '^2.0'),
         );
 
         $this->subject->installTemplateSource($templateSource);
@@ -175,7 +173,7 @@ final class BaseProviderTest extends Tests\ContainerAwareTestCase
     public function installTemplateSourceAllowsSpecifyingOtherConstraintIfInstallationFailsWithGivenConstraint(): void
     {
         $package = $this->createPackageFromTemplateFixture();
-        $templateSource = new Template\TemplateSource($this->subject, $package);
+        $templateSource = new Src\Template\TemplateSource($this->subject, $package);
 
         $this->subject->packages = [$package];
 
@@ -205,7 +203,7 @@ final class BaseProviderTest extends Tests\ContainerAwareTestCase
         string $constraint,
         string $expected,
     ): void {
-        $templateSource = new Template\TemplateSource($this->subject, reset($packages));
+        $templateSource = new Src\Template\TemplateSource($this->subject, reset($packages));
 
         $this->subject->packages = $packages;
 
@@ -310,7 +308,7 @@ final class BaseProviderTest extends Tests\ContainerAwareTestCase
 
         self::assertDirectoryExists($fixturePath);
 
-        $composerJson = Resource\Local\Composer::createComposer($fixturePath);
+        $composerJson = Src\Resource\Local\Composer::createComposer($fixturePath);
         $package = $this->createPackage($composerJson->getPackage()->getName(), prettyVersion: $prettyVersion);
 
         $package->setDistType('path');


### PR DESCRIPTION
Version constraints for selected template packages are now validated with Composer's `VersionParser`. In case an invalid version constraint was entered, the user can now enter another constraint (or leave it empty to let Composer decide on the version itself). For this, a new `CallbackValidator` was introduced.