### PR TITLE
[TASK] Exclude development-only files from Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+/.github
+/docs
+/tests
+/.dockerignore
+/.editorconfig
+/.gitattributes
+/.php-cs-fixer.php
+/codecov.yml
+/CONTRIBUTING.md
+/dependency-checker.json
+/Dockerfile
+/phpstan.neon
+/phpunit.coverage.xml
+/phpunit.xml
+/README.md
+/rector.php

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 *                         text=auto
 /.github                  export-ignore
 /tests                    export-ignore
+/.dockerignore            export-ignore
 /.editorconfig            export-ignore
 /.gitattributes           export-ignore
 /.gitignore               export-ignore


### PR DESCRIPTION
Several development-only files must not reside in the final Docker image, therefore they're now ignored for `docker build`.