### PR TITLE
[FEATURE] Introduce input reader option for hidden input

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -150,6 +150,7 @@ Example:
 
 $phpVersion = $inputReader->choices('Which PHP version should be used?', ['8.1', '8.0']);
 $name = $inputReader->staticValue('What\'s your name?');
+$password = $inputReader->hiddenValue('What\'s your password?');
 
 if ($inputReader->ask('Confirm project generation?', default: false)) {
     // Project generation confirmed, continue...

--- a/src/IO/InputReader.php
+++ b/src/IO/InputReader.php
@@ -76,6 +76,13 @@ final class InputReader
         return null;
     }
 
+    public function hiddenValue(string $label): ?string
+    {
+        $label = Messenger::decorateLabel($label);
+
+        return $this->io->askAndHideAnswer($label);
+    }
+
     /**
      * @param list<string> $choices
      *

--- a/tests/src/IO/InputReaderTest.php
+++ b/tests/src/IO/InputReaderTest.php
@@ -59,4 +59,19 @@ final class InputReaderTest extends Tests\ContainerAwareTestCase
     {
         self::assertSame('Alice', $this->subject->staticValue('What\'s your name?', 'Alice'));
     }
+
+    /**
+     * @test
+     */
+    public function hiddenValueHidesUserInput(): void
+    {
+        self::$io->setUserInputs(['s3cr3t']);
+
+        self::assertSame('s3cr3t', $this->subject->hiddenValue('What\'s your password?'));
+
+        $output = self::$io->getOutput();
+
+        self::assertStringContainsString('What\'s your password?', $output);
+        self::assertStringNotContainsString('s3cr3t', $output);
+    }
 }


### PR DESCRIPTION
This PR introduces a new `IO\InputReader::hiddenValue()` method. It can be used to obtain sensitive user input, being hidden to the current IO.