### PR TITLE
[FEATURE] Allow writing multiple messages at once

### DIFF
--- a/src/Builder/Generator/Step/ShowNextStepsStep.php
+++ b/src/Builder/Generator/Step/ShowNextStepsStep.php
@@ -63,10 +63,7 @@ final class ShowNextStepsStep extends AbstractStep
         $nextSteps = explode(PHP_EOL, trim($renderer->render($buildResult->getInstructions(), basename($templateFile))));
 
         $this->messenger->section('Next steps');
-
-        foreach ($nextSteps as $nextStep) {
-            $this->messenger->write($nextStep);
-        }
+        $this->messenger->write($nextSteps);
 
         $buildResult->applyStep($this);
 

--- a/src/IO/Messenger.php
+++ b/src/IO/Messenger.php
@@ -31,6 +31,7 @@ use CPSIT\ProjectBuilder\Resource;
 use CPSIT\ProjectBuilder\Template;
 use Symfony\Component\Console;
 
+use function array_map;
 use function count;
 use function implode;
 use function is_scalar;
@@ -340,11 +341,12 @@ final class Messenger
     }
 
     /**
+     * @param string|list<string>            $messages
      * @param int-mask-of<IO\IOInterface::*> $verbosity
      */
-    public function write(string $message, bool $newLine = true, int $verbosity = IO\IOInterface::NORMAL): void
+    public function write(string|array $messages, bool $newLine = true, int $verbosity = IO\IOInterface::NORMAL): void
     {
-        $this->getIO()->write($message, $newLine, $verbosity);
+        $this->getIO()->write($messages, $newLine, $verbosity);
     }
 
     public function writeWithEmoji(string $emoji, string $message, bool $overwrite = false): void


### PR DESCRIPTION
The `IO\Messenger::write()` method can now handle multiple messages at once. For this, the first argument now allows a list of string values:

```php
$messenger->write('foo');
$messenger->write('baz');

// equals

$messenger->write(['foo', 'baz']);
```