### PR TITLE
[BUGFIX] Reset mock handler queue between test scenarios

### DIFF
--- a/tests/src/ContainerAwareTestCase.php
+++ b/tests/src/ContainerAwareTestCase.php
@@ -131,5 +131,6 @@ abstract class ContainerAwareTestCase extends TestCase
     protected function tearDown(): void
     {
         self::$io->reset();
+        self::$mockHandler->reset();
     }
 }


### PR DESCRIPTION
The mock handler queue must be cleared on tear down, otherwise tests can not be isolated properly from each other.