### PR TITLE
[TASK] Use release token in GitHub release job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,4 +25,5 @@ jobs:
       - name: Create release
         uses: ncipollo/release-action@v1
         with:
+          token: ${{ secrets.RELEASE_TOKEN }}
           generateReleaseNotes: true


### PR DESCRIPTION
The @cpsitgmbh user may create releases in the future using our organization-wide release token :pray: