### PR TITLE
[BUGFIX] Respect include files when reading Git configuration

### DIFF
--- a/src/Resource/Local/Git.php
+++ b/src/Resource/Local/Git.php
@@ -56,6 +56,7 @@ final class Git
             ->addArgument('config')
             ->addOption('--global')
             ->addOption('--default', '')
+            ->addOption('--includes')
             ->addOption('--get')
             ->addOption($configPath)
         ;


### PR DESCRIPTION
If [include files](https://git-scm.com/docs/git-config#_includes) are configured in the global `.gitconfig` file, they should be respected when reading Git configuration. This is now done by passing the [`--includes`](https://git-scm.com/docs/git-config#Documentation/git-config.txt---no-includes) option.