### PR TITLE
[BUGFIX] Ignore uncoverable code from code coverage

### DIFF
--- a/src/Template/Provider/BaseProvider.php
+++ b/src/Template/Provider/BaseProvider.php
@@ -107,10 +107,12 @@ abstract class BaseProvider implements ProviderInterface
     {
         $package = $templateSource->getPackage();
 
+        // @codeCoverageIgnoreStart
         if ($package instanceof Package\AliasPackage) {
             $package = $package->getAliasOf();
             $templateSource->setPackage($package);
         }
+        // @codeCoverageIgnoreEnd
 
         if ($package instanceof Package\Package) {
             $this->requestPackageVersionConstraint($templateSource);


### PR DESCRIPTION
This code snippet causes much confusion to codecov, since sometimes it's covered and sometimes it isn't. Since we cannot rely on that code being covered, we can safely ignore it from code coverage.