### PR TITLE
[TASK] Introduce Docker test suite

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -99,4 +99,4 @@ jobs:
 
       # Run Docker tests
       - name: Run Docker tests
-        run: tests/docker/docker-build.sh --verbose
+        run: tests/docker/docker-build.sh --cache --verbose

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -97,6 +97,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Handle Docker image layer cache
+      - name: Restore Docker cache
+        uses: satackey/action-docker-layer-caching@v0.0.11
+        continue-on-error: true
+
       # Run Docker tests
       - name: Run Docker tests
         run: tests/docker/docker-build.sh --cache --verbose

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -63,11 +63,11 @@ jobs:
         with:
           dependency-versions: highest
 
-      # Run tests
+      # Run Unit tests
       - name: Build coverage directory
         run: mkdir -p .build/coverage
-      - name: Run tests with coverage
-        run: composer test:coverage
+      - name: Run Unit tests with coverage
+        run: composer test:unit:coverage
 
       # Report coverage
       - name: Fix coverage path
@@ -88,3 +88,15 @@ jobs:
           directory: .build/coverage
           fail_ci_if_error: true
           verbose: true
+
+  docker:
+    name: Docker tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      # Run Docker tests
+      - name: Run Docker tests
+        run: tests/docker/docker-build.sh --verbose

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -98,7 +98,7 @@ jobs:
           fetch-depth: 0
 
       # Handle Docker image layer cache
-      - name: Restore Docker cache
+      - name: Handle Docker cache
         uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ all steps below.
 
 - Composer >= 2.1
 - PHP >= 8.0
+- Docker
 
 ## Preparation
 
@@ -50,8 +51,14 @@ composer sca:php
 # All tests
 composer test
 
-# All tests with code coverage
-composer test:coverage
+# Docker tests
+composer test:docker
+
+# Unit tests
+composer test:unit
+
+# Unit tests with code coverage
+composer test:unit:coverage
 ```
 
 ### Test reports

--- a/composer.json
+++ b/composer.json
@@ -106,8 +106,13 @@
 			"Composer\\Config::disableProcessTimeout",
 			"CPSIT\\ProjectBuilder\\Bootstrap::simulateCreateProject"
 		],
-		"test": "phpunit -c phpunit.xml",
-		"test:coverage": "phpunit -c phpunit.coverage.xml",
+		"test": [
+			"@test:unit",
+			"@test:docker"
+		],
+		"test:docker": "tests/docker/docker-build.sh",
+		"test:unit": "phpunit -c phpunit.xml",
+		"test:unit:coverage": "phpunit -c phpunit.coverage.xml",
 		"validate-schema": "docker run --rm -v \"$(pwd)\":/code swaggest/json-cli json-cli validate-schema resources/config.schema.json"
 	}
 }

--- a/tests/docker/docker-build.sh
+++ b/tests/docker/docker-build.sh
@@ -9,6 +9,7 @@ readonly expected="This command cannot be run in non-interactive mode."
 # Resolve parameters
 cache=0
 verbose=0
+root_version=""
 while [[ $# -gt 0 ]]; do
     key="$1"
     case ${key} in
@@ -20,16 +21,25 @@ while [[ $# -gt 0 ]]; do
         verbose=1
         shift
         ;;
+    *)
+        root_version="$1"
+        shift
+        ;;
     esac
 done
+
+# Determine root version
+if [ -z "$root_version" ]; then
+    root_version="$(git describe --tags --abbrev=0)"
+fi
 
 # Build and tag new image
 if [ "$cache" -eq 1 ]; then
     printf "Building image from cache... "
-    docker build --cache-from "$image_name" -q -t "$image_name" "$root_path" >/dev/null
+    docker build --cache-from "$image_name" -q -t "$image_name" --build-arg "PROJECT_BUILDER_VERSION=$root_version" "$root_path" >/dev/null
 else
     printf "Building image... "
-    docker build -q -t "$image_name" "$root_path" >/dev/null
+    docker build -q -t "$image_name" --build-arg "PROJECT_BUILDER_VERSION=$root_version" "$root_path" >/dev/null
 fi
 printf "\033[0;32mDone\033[0m\n"
 

--- a/tests/docker/docker-build.sh
+++ b/tests/docker/docker-build.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2155
+set -e
+
+readonly root_path="$(cd -- "$(dirname "$0")/../.." >/dev/null 2>&1; pwd -P)"
+readonly image_name="project-builder-test"
+readonly expected="This command cannot be run in non-interactive mode."
+
+# Check verbose mode
+if [ "-v" = "$1" ] || [ "--verbose" = "$1" ]; then
+    readonly verbose=1
+fi
+
+# Build and tag new image
+printf "Building image... "
+docker build -q -t "$image_name" "$root_path" >/dev/null
+printf "\033[0;32mDone\033[0m\n"
+
+# Run image
+printf "Running image... "
+set +e; readonly output="$(docker run --rm "$image_name" 2>&1)"; set -e
+printf "\033[0;32mDone\033[0m\n"
+
+# Remove image
+printf "Removing image... "
+docker rmi "$image_name" >/dev/null
+printf "\033[0;32mDone\033[0m\n"
+
+# Print output
+if [ "$verbose" = 1 ]; then
+    echo -e "\n============================================================\n"
+    echo "$output"
+    echo -e "\n============================================================"
+fi
+
+# Check output
+if [[ $output != *"$expected"* ]]; then
+    >&2 echo -e "\n🚨 Failed."
+    exit 1
+fi
+
+echo -e "\n✅ Success."

--- a/tests/docker/docker-build.sh
+++ b/tests/docker/docker-build.sh
@@ -6,24 +6,38 @@ readonly root_path="$(cd -- "$(dirname "$0")/../.." >/dev/null 2>&1; pwd -P)"
 readonly image_name="project-builder-test"
 readonly expected="This command cannot be run in non-interactive mode."
 
-# Check verbose mode
-if [ "-v" = "$1" ] || [ "--verbose" = "$1" ]; then
-    readonly verbose=1
-fi
+# Resolve parameters
+cache=0
+verbose=0
+while [[ $# -gt 0 ]]; do
+    key="$1"
+    case ${key} in
+    -c | --cache)
+        cache=1
+        shift
+        ;;
+    -v | --verbose)
+        verbose=1
+        shift
+        ;;
+    esac
+done
 
 # Build and tag new image
-printf "Building image... "
-docker build -q -t "$image_name" "$root_path" >/dev/null
+if [ "$cache" -eq 1 ]; then
+    printf "Building image from cache... "
+    docker build --cache-from "$image_name" -q -t "$image_name" "$root_path" >/dev/null
+else
+    printf "Building image... "
+    docker build -q -t "$image_name" "$root_path" >/dev/null
+fi
 printf "\033[0;32mDone\033[0m\n"
 
 # Run image
 printf "Running image... "
-set +e; readonly output="$(docker run --rm "$image_name" 2>&1)"; set -e
-printf "\033[0;32mDone\033[0m\n"
-
-# Remove image
-printf "Removing image... "
-docker rmi "$image_name" >/dev/null
+set +e
+readonly output="$(docker run --rm "$image_name" 2>&1)"
+set -e
 printf "\033[0;32mDone\033[0m\n"
 
 # Print output
@@ -35,7 +49,7 @@ fi
 
 # Check output
 if [[ $output != *"$expected"* ]]; then
-    >&2 echo -e "\n🚨 Failed."
+    echo >&2 -e "\n🚨 Failed."
     exit 1
 fi
 


### PR DESCRIPTION
This PR adds a test suite to test the correct behavior of the distributed Docker image. The test suite can be started in two ways:

* Run `composer test` to execute all tests (Unit tests + Docker tests)
* Run `composer test:docker` to execute only Docker tests

At the moment, the test suite only tests whether the image can be built and run in non-TTY mode. Thus, it checks whether to exit early with a warning about the current non-interactive environment. More tests may be added in the future.

> **Note** The Composer scripts for Unit tests have been renamed:
> 
> * `composer test` → `composer test:unit`
> * `composer test:coverage` → `composer test:unit:coverage`