### PR TITLE
[BUGFIX] Ignore ext-sockets platform req in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM composer:2.5 AS composer
 LABEL maintainer="Elias Häußler <e.haeussler@familie-redlich.de>"
 
-FROM php:8.1-alpine
+FROM php:8.2-alpine
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 ENV COMPOSER_ALLOW_SUPERUSER=1
@@ -13,12 +13,12 @@ WORKDIR /project-builder
 # Install Git and php-zip extension
 RUN apk update \
     && apk add git libzip-dev zip \
-    && docker-php-ext-install zip sockets
+    && docker-php-ext-install zip
 
 # Build project-builder artifact for later use in entrypoint
 ARG PROJECT_BUILDER_VERSION=0.0.0
 RUN composer config version "$PROJECT_BUILDER_VERSION" \
-    && composer update --prefer-dist --no-dev --no-install \
+    && composer update --prefer-dist --no-dev --no-install --ignore-platform-req=ext-sockets \
     && git add -f composer.lock \
     && mkdir artifacts \
     && git stash \


### PR DESCRIPTION
The `ext-sockets` platform requirement is a dependency of the dev-requirement `donatj/mock-webserver`. Since dev-requirements are not installed in the docker container, we can safely ignore this requirement.