### PR TITLE
[DOCS] Update documentation url

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,4 +4,4 @@ Thanks for considering contributing to this project! Each contribution is
 highly appreciated. Please have a look at the [official documentation][1]
 to get an overview about our contribution workflow.
 
-[1]: https://cps-it.github.io/project-builder/contributing/workflow.html
+[1]: https://project-builder.cps-it.de/contributing/workflow.html

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![Docker](https://img.shields.io/docker/v/cpsit/project-builder?label=docker&sort=semver)](https://hub.docker.com/r/cpsit/project-builder)
 [![License](http://poser.pugx.org/cpsit/project-builder/license)](LICENSE)
 
-📙&nbsp;**[Documentation](https://cps-it.github.io/project-builder/)** |
+📙&nbsp;**[Documentation](https://project-builder.cps-it.de/)** |
 📦&nbsp;[Packagist](https://packagist.org/packages/cpsit/project-builder) |
 💾&nbsp;[Repository](https://github.com/CPS-IT/project-builder) |
 🐛&nbsp;[Issue tracker](https://github.com/CPS-IT/project-builder/issues)
@@ -37,4 +37,4 @@ Please have a look at [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 This project is licensed under [GNU General Public License 3.0 (or later)](LICENSE).
 
-[1]: https://cps-it.github.io/project-builder/
+[1]: https://project-builder.cps-it.de/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,7 +56,7 @@ html_theme_options = {
 # -- OpenGraph configuration -------------------------------------------------
 # https://github.com/wpilibsuite/sphinxext-opengraph#options
 
-opg_site_url = "https://cps-it.github.io/project-builder/"
+opg_site_url = "https://project-builder.cps-it.de/"
 opg_image = "_static/img/header.png"
 ogp_enable_meta_description = False
 


### PR DESCRIPTION
This PR updates the documentation url to the new domain: https://project-builder.cps-it.de/