### PR TITLE
[TASK] Remove PHP_CS_FIXER_IGNORE_ENV compatibility flag

### DIFF
--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -51,9 +51,6 @@ jobs:
         run: composer lint:json
       - name: Lint PHP
         run: composer lint:php -- --dry-run --format=checkstyle | cs2pr
-        env:
-          # @todo Remove once PHP-CS-Fixer officially supports PHP 8.2
-          PHP_CS_FIXER_IGNORE_ENV: 1
 
       # SCA
       - name: SCA PHP


### PR DESCRIPTION
Since PHP-CS-Fixer now officially supports PHP 8.2, we can safely remove the introduced compatibility flag.

:bulb: This partially reverts commit cbe2ab5941f586cf1627b7411fb9f4c604b15e45.