### PR TITLE
[BUGFIX] Improve type-safety of utility methods in ArrayHelper

### DIFF
--- a/src/Helper/ArrayHelper.php
+++ b/src/Helper/ArrayHelper.php
@@ -34,9 +34,9 @@ use ArrayObject;
 final class ArrayHelper
 {
     /**
-     * @param iterable<string, mixed> $subject
+     * @param array<string, mixed>|ArrayObject<string, mixed> $subject
      */
-    public static function getValueByPath(iterable $subject, string $path): mixed
+    public static function getValueByPath(array|ArrayObject $subject, string $path): mixed
     {
         $pathSegments = array_filter(explode('.', $path));
         $reference = &$subject;
@@ -53,18 +53,25 @@ final class ArrayHelper
     }
 
     /**
-     * @param iterable<string, mixed> $subject
+     * @param array<string, mixed>|ArrayObject<string, mixed> $subject
      */
-    public static function setValueByPath(iterable &$subject, string $path, mixed $value): void
+    public static function setValueByPath(array|ArrayObject &$subject, string $path, mixed $value): void
     {
         $pathSegments = array_filter(explode('.', $path));
         $reference = &$subject;
 
         foreach ($pathSegments as $pathSegment) {
+            // Instantiate array if path segment does not exist
             if (!self::pathSegmentExists($reference, $pathSegment)) {
                 $reference[$pathSegment] = [];
             }
 
+            // Overwrite unsupported value as empty array
+            if (!is_array($reference[$pathSegment]) && !($reference[$pathSegment] instanceof ArrayObject)) {
+                $reference[$pathSegment] = [];
+            }
+
+            // Move pointer forward to current path
             $reference = &$reference[$pathSegment];
         }
 

--- a/tests/src/Helper/ArrayHelperTest.php
+++ b/tests/src/Helper/ArrayHelperTest.php
@@ -25,6 +25,7 @@ namespace CPSIT\ProjectBuilder\Tests\Helper;
 
 use CPSIT\ProjectBuilder as Src;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 /**
  * ArrayHelperTest.
@@ -39,15 +40,25 @@ final class ArrayHelperTest extends TestCase
      */
     public function getValueByPathReturnsValueAtGivenPath(): void
     {
+        $object = new stdClass();
         $subject = [
             'foo' => [
                 'bar' => 'hello world!',
+                'baz' => $object,
             ],
         ];
 
         self::assertSame('hello world!', Src\Helper\ArrayHelper::getValueByPath($subject, 'foo.bar'));
-        self::assertSame(['bar' => 'hello world!'], Src\Helper\ArrayHelper::getValueByPath($subject, 'foo'));
+        self::assertSame($object, Src\Helper\ArrayHelper::getValueByPath($subject, 'foo.baz'));
+        self::assertSame(
+            [
+                'bar' => 'hello world!',
+                'baz' => $object,
+            ],
+            Src\Helper\ArrayHelper::getValueByPath($subject, 'foo'),
+        );
         self::assertNull(Src\Helper\ArrayHelper::getValueByPath($subject, 'bar'));
+        self::assertNull(Src\Helper\ArrayHelper::getValueByPath($subject, 'foo.baz.boo'));
     }
 
     /**
@@ -58,12 +69,17 @@ final class ArrayHelperTest extends TestCase
         $subject = [
             'foo' => [
                 'bar' => 'hello world!',
+                'baz' => new stdClass(),
             ],
         ];
 
         Src\Helper\ArrayHelper::setValueByPath($subject, 'foo.bar', 'bye!');
 
         self::assertSame('bye!', Src\Helper\ArrayHelper::getValueByPath($subject, 'foo.bar'));
+
+        Src\Helper\ArrayHelper::setValueByPath($subject, 'foo.baz.boo', 'foo');
+
+        self::assertSame('foo', Src\Helper\ArrayHelper::getValueByPath($subject, 'foo.baz.boo'));
 
         Src\Helper\ArrayHelper::setValueByPath($subject, 'bar', 'hello world!');
 
@@ -73,6 +89,9 @@ final class ArrayHelperTest extends TestCase
             [
                 'foo' => [
                     'bar' => 'bye!',
+                    'baz' => [
+                        'boo' => 'foo',
+                    ],
                 ],
                 'bar' => 'hello world!',
             ],


### PR DESCRIPTION
The `getValueByPath` and `setValueByPath` utility methods in `ArrayHelper` only support arrays and objects of `ArrayObject`. However, the types were not written as such. That's why they're hardened now to improve type-safety. In addition, some more test cases were added to cover all relevant side-effects of those methods.