### PR TITLE
[DOCS] Lock Furo version to 2022.12.7

### DIFF
--- a/docs/_build/Dockerfile
+++ b/docs/_build/Dockerfile
@@ -1,11 +1,11 @@
 FROM sphinxdoc/sphinx
 
 RUN pip3 install \
-  furo \
-  myst-parser \
-  sphinx-autobuild \
-  sphinx-copybutton \
-  sphinx-design \
-  sphinxext-opengraph
+  furo==2022.12.7 \
+  myst-parser==1.0.0 \
+  sphinx-autobuild==2021.3.14 \
+  sphinx-copybutton==0.5.1 \
+  sphinx-design==0.3.0 \
+  sphinxext-opengraph==0.8.1
 
 WORKDIR /app


### PR DESCRIPTION
The new version somehow breaks card links in the "Getting started" section. We need to figure out what's going on there.