### PR TITLE
[TASK] Allow $schema property in config files

### DIFF
--- a/resources/config.schema.json
+++ b/resources/config.schema.json
@@ -3,6 +3,10 @@
 	"type": "object",
 	"title": "Project builder template configuration",
 	"properties": {
+		"$schema": {
+			"type": "string",
+			"title": "Public URL to this JSON schema file"
+		},
 		"name": {
 			"type": "string",
 			"title": "Project template name",

--- a/src/Builder/Config/ConfigFactory.php
+++ b/src/Builder/Config/ConfigFactory.php
@@ -132,6 +132,9 @@ final class ConfigFactory
         // Enforce custom identifier
         $parsedContent['identifier'] = $identifier;
 
+        // Unset $schema property
+        unset($parsedContent['$schema']);
+
         return Mapper\Source\Source::array($parsedContent);
     }
 
@@ -145,6 +148,9 @@ final class ConfigFactory
         if (!($parsedContent instanceof stdClass)) {
             throw Exception\InvalidConfigurationException::forSource($content);
         }
+
+        // Unset $schema property
+        unset($parsedContent->{'$schema'});
 
         return $parsedContent;
     }

--- a/tests/src/Fixtures/Templates/json-template/config.json
+++ b/tests/src/Fixtures/Templates/json-template/config.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://raw.githubusercontent.com/CPS-IT/project-builder/main/resources/config.schema.json",
 	"name": "Json",
 	"steps": [
 		{

--- a/tests/src/Fixtures/Templates/yaml-template/config.yaml
+++ b/tests/src/Fixtures/Templates/yaml-template/config.yaml
@@ -1,3 +1,5 @@
+$schema: https://raw.githubusercontent.com/CPS-IT/project-builder/main/resources/config.schema.json
+
 name: Yaml
 
 steps:


### PR DESCRIPTION
This PR extends the config schema to allow `$schema` properties in config files. This is especially helpful when developing custom template packages since most IDEs understand the `$schema` property and can therefore provide autocompletion for template configuration. Internally, the `$schema` property is unset during config parsing as it's not relevant for the project builder.