### PR TITLE
[FEATURE] Introduce RegexValidator

### DIFF
--- a/docs/development/architecture/components.md
+++ b/docs/development/architecture/components.md
@@ -61,6 +61,7 @@ As an additional I/O component, some **validators** exist, ready to be used by t
 | `callback` | [`CallbackValidator`](https://github.com/CPS-IT/project-builder/blob/main/src/IO/Validator/CallbackValidator.php) | User input is validated by a given callback          |
 | `email`    | [`EmailValidator`](https://github.com/CPS-IT/project-builder/blob/main/src/IO/Validator/EmailValidator.php)       | User input must be a valid e-mail address            |
 | `notEmpty` | [`NotEmptyValidator`](https://github.com/CPS-IT/project-builder/blob/main/src/IO/Validator/NotEmptyValidator.php) | User input must not be empty (strict mode available) |
+| `regex`    | [`RegexValidator`](https://github.com/CPS-IT/project-builder/blob/main/src/IO/Validator/RegexValidator.php)       | User input must match a given regular expression     |
 | `url`      | [`UrlValidator`](https://github.com/CPS-IT/project-builder/blob/main/src/IO/Validator/UrlValidator.php)           | User input must be a valid URL                       |
 
 Each validator implements [`ValidatorInterface`](https://github.com/CPS-IT/project-builder/blob/main/src/IO/Validator/ValidatorInterface.php).

--- a/resources/config.schema.json
+++ b/resources/config.schema.json
@@ -197,6 +197,7 @@
 					"enum": [
 						"email",
 						"notEmpty",
+						"regex",
 						"url"
 					]
 				},

--- a/src/IO/Validator/RegexValidator.php
+++ b/src/IO/Validator/RegexValidator.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/project-builder".
+ *
+ * Copyright (C) 2023 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\ProjectBuilder\IO\Validator;
+
+use CPSIT\ProjectBuilder\Exception;
+
+use function is_string;
+use function preg_match;
+
+/**
+ * RegexValidator.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ *
+ * @extends AbstractValidator<array{pattern: non-empty-string, errorMessage: non-empty-string}>
+ */
+final class RegexValidator extends AbstractValidator
+{
+    private const TYPE = 'regex';
+
+    protected static array $defaultOptions = [
+        'pattern' => '/.*/',
+        'errorMessage' => 'The given input does not match the required pattern.',
+    ];
+
+    /**
+     * @param array{pattern?: non-empty-string, errorMessage?: non-empty-string} $options
+     */
+    public function __construct(array $options = [])
+    {
+        if (!is_string($options['pattern'] ?? null)) {
+            throw Exception\MisconfiguredValidatorException::forUnexpectedOption($this, 'pattern');
+        }
+        if (false === @preg_match($options['pattern'], '')) {
+            throw Exception\MisconfiguredValidatorException::forUnexpectedOption($this, 'pattern');
+        }
+
+        parent::__construct($options);
+    }
+
+    public function __invoke(?string $input): ?string
+    {
+        if (1 !== preg_match($this->options['pattern'], (string) $input)) {
+            throw Exception\ValidationException::create($this->options['errorMessage']);
+        }
+
+        return $input;
+    }
+
+    public static function getType(): string
+    {
+        return self::TYPE;
+    }
+
+    public static function supports(string $type): bool
+    {
+        return self::TYPE === $type;
+    }
+}

--- a/tests/src/IO/Validator/RegexValidatorTest.php
+++ b/tests/src/IO/Validator/RegexValidatorTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/project-builder".
+ *
+ * Copyright (C) 2023 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\ProjectBuilder\Tests\IO\Validator;
+
+use CPSIT\ProjectBuilder as Src;
+use PHPUnit\Framework;
+
+/**
+ * RegexValidatorTest.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+final class RegexValidatorTest extends Framework\TestCase
+{
+    private Src\IO\Validator\RegexValidator $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new Src\IO\Validator\RegexValidator([
+            'pattern' => '/^[a-zA-Z]+$/',
+            'errorMessage' => 'Only letters, please!',
+        ]);
+    }
+
+    #[Framework\Attributes\Test]
+    public function constructorThrowsExceptionIfNoPatternIsGiven(): void
+    {
+        $this->expectExceptionObject(
+            Src\Exception\MisconfiguredValidatorException::forUnexpectedOption($this->subject, 'pattern'),
+        );
+
+        new Src\IO\Validator\RegexValidator();
+    }
+
+    #[Framework\Attributes\Test]
+    public function constructorThrowsExceptionIfInvalidPatternIsGiven(): void
+    {
+        $this->expectExceptionObject(
+            Src\Exception\MisconfiguredValidatorException::forUnexpectedOption($this->subject, 'pattern'),
+        );
+
+        new Src\IO\Validator\RegexValidator(['pattern' => 'foo']);
+    }
+
+    #[Framework\Attributes\Test]
+    public function invokeThrowsExceptionOnUnmatchedInput(): void
+    {
+        $this->expectExceptionObject(
+            Src\Exception\ValidationException::create('Only letters, please!'),
+        );
+
+        ($this->subject)('Hello world!');
+    }
+
+    #[Framework\Attributes\Test]
+    public function invokeValidatesInputAgainstConfiguredPattern(): void
+    {
+        $actual = ($this->subject)('foo');
+
+        self::assertSame('foo', $actual);
+    }
+}

--- a/tests/src/IO/Validator/ValidatorFactoryTest.php
+++ b/tests/src/IO/Validator/ValidatorFactoryTest.php
@@ -25,6 +25,7 @@ namespace CPSIT\ProjectBuilder\Tests\IO\Validator;
 
 use CPSIT\ProjectBuilder as Src;
 use CPSIT\ProjectBuilder\Tests;
+use Generator;
 use PHPUnit\Framework;
 
 /**
@@ -54,12 +55,18 @@ final class ValidatorFactoryTest extends Tests\ContainerAwareTestCase
         $this->subject->get($validator);
     }
 
+    /**
+     * @param non-empty-string                                  $type
+     * @param array<string, int|float|string|bool>              $options
+     * @param class-string<Src\IO\Validator\ValidatorInterface> $expected
+     */
     #[Framework\Attributes\Test]
-    public function getReturnsValidatorForGivenType(): void
+    #[Framework\Attributes\DataProvider('getReturnsValidatorForGivenTypeDataProvider')]
+    public function getReturnsValidatorForGivenType(string $type, array $options, string $expected): void
     {
-        $validator = new Src\Builder\Config\ValueObject\PropertyValidator('email');
+        $validator = new Src\Builder\Config\ValueObject\PropertyValidator($type, $options);
 
-        self::assertInstanceOf(Src\IO\Validator\EmailValidator::class, $this->subject->get($validator));
+        self::assertInstanceOf($expected, $this->subject->get($validator));
     }
 
     #[Framework\Attributes\Test]
@@ -72,6 +79,20 @@ final class ValidatorFactoryTest extends Tests\ContainerAwareTestCase
 
         self::assertTrue($actual->has(new Src\IO\Validator\EmailValidator()));
         self::assertTrue($actual->has(new Src\IO\Validator\NotEmptyValidator()));
+        self::assertFalse($actual->has(new Src\IO\Validator\CallbackValidator(['callback' => fn () => null])));
+        self::assertFalse($actual->has(new Src\IO\Validator\RegexValidator(['pattern' => '/.*/'])));
         self::assertFalse($actual->has(new Src\IO\Validator\UrlValidator()));
+    }
+
+    /**
+     * @return Generator<string, array{non-empty-string, array<string, int|float|string|bool>, class-string<Src\IO\Validator\ValidatorInterface>}>
+     */
+    public static function getReturnsValidatorForGivenTypeDataProvider(): Generator
+    {
+        yield 'callback' => ['callback', ['callback' => 'trim'], Src\IO\Validator\CallbackValidator::class];
+        yield 'email' => ['email', [], Src\IO\Validator\EmailValidator::class];
+        yield 'notEmpty' => ['notEmpty', [], Src\IO\Validator\NotEmptyValidator::class];
+        yield 'regex' => ['regex', ['pattern' => '/.*/'], Src\IO\Validator\RegexValidator::class];
+        yield 'url' => ['url', [], Src\IO\Validator\UrlValidator::class];
     }
 }


### PR DESCRIPTION
This PR introduces a new `RegexValidator`. It can be used to validate a given input against a regular expression. The regular expression must be configured through validator option `pattern`. In addition, a custom error message can be configured by using validator option `errorMessage`. If omitted, a default error message is used.

Resolves: #151