### PR TITLE
[FEATURE] Loosen requirement for "if" condition if "target" is set

### DIFF
--- a/docs/development/configuration.md
+++ b/docs/development/configuration.md
@@ -166,11 +166,9 @@ steps:
           if: 'false'
         # Mirror an entire directory
         - path: 'source-dir/*'
-          if: 'true'
           target: 'target-dir/*'
         # Apply Twig expression for custom target directory names
         - path: 'source-dir/*'
-          if: 'true'
           target: '{{ project.name | slugify }}-target-dir/*'
   - type: mirrorProcessedFiles
   - type: showNextSteps

--- a/resources/config.schema.json
+++ b/resources/config.schema.json
@@ -310,44 +310,61 @@
 							"type": "string",
 							"title": "Relative path to a file, can contain symbols processable by `fnmatch`",
 							"description": "Can also be a directory ending with `/*`, to recursively match all files below"
-						},
-						"target": {
-							"type": "string",
-							"title": "Relative path to target file, can be used to override the default path",
-							"description": "Can also be a directory ending with `/*`, to exchange the base source path"
 						}
 					}
 				},
 				{
 					"oneOf": [
 						{
-							"properties": {
-								"path": {
-									"pattern": "/\\*$"
-								},
-								"target": {
-									"pattern": "/\\*$"
-								}
-							}
+							"not": {
+								"required": [
+									"target"
+								]
+							},
+							"required": [
+								"path",
+								"if"
+							]
 						},
 						{
 							"properties": {
-								"path": {
-									"pattern": "(?<!\\*)$"
-								},
 								"target": {
-									"pattern": "(?<!\\*)$"
+									"type": "string",
+									"title": "Relative path to target file, can be used to override the default path",
+									"description": "Can also be a directory ending with `/*`, to exchange the base source path"
 								}
-							}
+							},
+							"oneOf": [
+								{
+									"properties": {
+										"path": {
+											"pattern": "/\\*$"
+										},
+										"target": {
+											"pattern": "/\\*$"
+										}
+									}
+								},
+								{
+									"properties": {
+										"path": {
+											"pattern": "(?<!\\*)$"
+										},
+										"target": {
+											"pattern": "(?<!\\*)$"
+										}
+									}
+								}
+							],
+							"required": [
+								"path",
+								"target"
+							]
 						}
 					]
 				}
 			],
-			"unevaluatedProperties": false,
-			"required": [
-				"if",
-				"path"
-			]
+			"unevaluatedProperties": false
 		},
 		"condition": {
 			"type": "string",

--- a/src/Builder/Config/ValueObject/FileCondition.php
+++ b/src/Builder/Config/ValueObject/FileCondition.php
@@ -35,7 +35,7 @@ final class FileCondition
 
     public function __construct(
         private readonly string $path,
-        string $if,
+        string $if = null,
         private readonly ?string $target = null,
     ) {
         $this->if = $if;

--- a/tests/src/Builder/Config/ConfigFactoryTest.php
+++ b/tests/src/Builder/Config/ConfigFactoryTest.php
@@ -70,7 +70,7 @@ final class ConfigFactoryTest extends Framework\TestCase
                         new Src\Builder\Config\ValueObject\FileCondition('*-3.'.$type, 'false'),
                         new Src\Builder\Config\ValueObject\FileCondition('dummy-4.'.$type, 'false'),
                         new Src\Builder\Config\ValueObject\FileCondition('dummy-4.'.$type, 'true', 'overrides/dummy-4.'.$type),
-                        new Src\Builder\Config\ValueObject\FileCondition('dummy/*', 'true', 'foo-{{ foo }}-dummy/*'),
+                        new Src\Builder\Config\ValueObject\FileCondition('dummy/*', null, 'foo-{{ foo }}-dummy/*'),
                     ]),
                 ),
                 new Src\Builder\Config\ValueObject\Step(
@@ -79,7 +79,7 @@ final class ConfigFactoryTest extends Framework\TestCase
                         new Src\Builder\Config\ValueObject\FileCondition('shared-dummy-2.'.$type, 'false'),
                         new Src\Builder\Config\ValueObject\FileCondition('shared-*-3.'.$type, 'false'),
                         new Src\Builder\Config\ValueObject\FileCondition('shared-dummy-4.'.$type, 'true', 'overrides/shared-dummy-4.'.$type),
-                        new Src\Builder\Config\ValueObject\FileCondition('shared-dummy/*', 'true', 'foo-{{ foo }}-shared-dummy/*'),
+                        new Src\Builder\Config\ValueObject\FileCondition('shared-dummy/*', null, 'foo-{{ foo }}-shared-dummy/*'),
                     ]),
                 ),
                 new Src\Builder\Config\ValueObject\Step(

--- a/tests/src/Fixtures/Templates/json-template/config.json
+++ b/tests/src/Fixtures/Templates/json-template/config.json
@@ -28,7 +28,6 @@
 					},
 					{
 						"path": "dummy/*",
-						"if": "true",
 						"target": "foo-{{ foo }}-dummy/*"
 					}
 				]
@@ -53,7 +52,6 @@
 					},
 					{
 						"path": "shared-dummy/*",
-						"if": "true",
 						"target": "foo-{{ foo }}-shared-dummy/*"
 					}
 				]

--- a/tests/src/Fixtures/Templates/yaml-template/config.yaml
+++ b/tests/src/Fixtures/Templates/yaml-template/config.yaml
@@ -17,7 +17,6 @@ steps:
           if: 'true'
           target: 'overrides/dummy-4.yaml'
         - path: 'dummy/*'
-          if: 'true'
           target: 'foo-{{ foo }}-dummy/*'
   - type: processSharedSourceFiles
     options:
@@ -30,7 +29,6 @@ steps:
           if: 'true'
           target: 'overrides/shared-dummy-4.yaml'
         - path: 'shared-dummy/*'
-          if: 'true'
           target: 'foo-{{ foo }}-shared-dummy/*'
   - type: generateBuildArtifact
     options:


### PR DESCRIPTION
This PR extends the config JSON schema to no longer require a `if` condition to be set for file conditions in case a `target` path is configured.

Example:

```diff
 steps:
   # ...
   - type: processSourceFiles
     options:
       fileConditions:
         - path: 'source-dir/*'
-          if: 'true'
           target: 'target-dir/*'
 # ...
```

💡 If no `target` path is configured, an `if` condition is still required.