### PR TITLE
[BUGFIX] Properly handle no selection for optional multi-select fields

### DIFF
--- a/src/IO/InputReader.php
+++ b/src/IO/InputReader.php
@@ -156,6 +156,11 @@ final class InputReader
             array_filter($answers, fn ($answer): bool => $noSelectionIndex !== (int) $answer),
         );
 
+        // Early return if no selection was made
+        if (null !== $noSelectionIndex && [] === $selections) {
+            return [];
+        }
+
         // @codeCoverageIgnoreStart
         if ([] === $selections) {
             throw Exception\ValidationException::create('No selection was made. Please try again.');

--- a/tests/src/IO/InputReaderTest.php
+++ b/tests/src/IO/InputReaderTest.php
@@ -69,4 +69,15 @@ final class InputReaderTest extends Tests\ContainerAwareTestCase
         self::assertStringContainsString('What\'s your password?', $output);
         self::assertStringNotContainsString('s3cr3t', $output);
     }
+
+    #[Framework\Attributes\Test]
+    public function choicesReturnsEmptyArrayIfNoSelectionWasMade(): void
+    {
+        self::$io->setUserInputs(['']);
+
+        self::assertSame(
+            [],
+            $this->subject->choices('Please make a selection.', ['foo', 'baz'], multiple: true),
+        );
+    }
 }


### PR DESCRIPTION
When using optional multi-select fields, it should be possible to omit a selection. Prior to this PR, the InputReader threw an exception in this case, which should never happen.