### PR TITLE
[BUGFIX] Perform legacy environment check as early as possible

### DIFF
--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -50,14 +50,15 @@ final class Bootstrap
         string $targetDirectory = null,
         bool $exitOnFailure = true,
     ): int {
-        $messenger = IO\Messenger::create($event->getIO());
-        $targetDirectory ??= Helper\FilesystemHelper::getProjectRootPath();
-
         // Early return if current environment is unsupported
         if (self::runsOnAnUnsupportedEnvironment()) {
             throw Exception\UnsupportedEnvironmentException::forOutdatedComposerInstallation();
         }
 
+        $messenger = IO\Messenger::create($event->getIO());
+        $targetDirectory ??= Helper\FilesystemHelper::getProjectRootPath();
+
+        // Create new project
         $exitCode = self::createApplication($messenger, $targetDirectory)->run();
 
         $event->stopPropagation();


### PR DESCRIPTION
The check for legacy/unsupported environments is currently not called early enough. This leads to the same issues as before. Thus, the check is now moved to an earlier position, making it available as early as possible.