### PR TITLE
[BUGFIX] Avoid usage of `ReflectionProperty::setAccessible()`

### DIFF
--- a/tests/src/Template/Provider/ComposerProviderTest.php
+++ b/tests/src/Template/Provider/ComposerProviderTest.php
@@ -109,8 +109,6 @@ final class ComposerProviderTest extends Tests\ContainerAwareTestCase
     {
         $reflectionObject = new ReflectionObject($object);
         $reflectionProperty = $reflectionObject->getProperty($propertyName);
-
-        $reflectionProperty->setAccessible(true);
         $reflectionProperty->setValue($object, $value);
     }
 

--- a/tests/src/Template/Provider/VcsProviderTest.php
+++ b/tests/src/Template/Provider/VcsProviderTest.php
@@ -186,10 +186,8 @@ final class VcsProviderTest extends Tests\ContainerAwareTestCase
     private function getReflectionProperty(object $object, string $propertyName): ReflectionProperty
     {
         $reflectionObject = new ReflectionObject($object);
-        $reflectionProperty = $reflectionObject->getProperty($propertyName);
-        $reflectionProperty->setAccessible(true);
 
-        return $reflectionProperty;
+        return $reflectionObject->getProperty($propertyName);
     }
 
     /**


### PR DESCRIPTION
Calling `ReflectionProperty::setAccessible()` has no effect since PHP 8.1.0. Thus, it can be safely removed.