### PR TITLE
[BUGFIX] Allow restarting project generation on step failure

### DIFF
--- a/src/Builder/Generator/Generator.php
+++ b/src/Builder/Generator/Generator.php
@@ -59,12 +59,16 @@ final class Generator
 
     public function run(string $targetDirectory): Builder\BuildResult
     {
+        // Reset cache of reverted steps
+        $this->revertedSteps = [];
+
         if (!$this->filesystem->exists($targetDirectory)) {
             $this->filesystem->mkdir($targetDirectory);
         }
 
         $instructions = new Builder\BuildInstructions($this->config, $targetDirectory);
         $result = new Builder\BuildResult($instructions);
+        $restart = false;
 
         $this->eventDispatcher->dispatch(new Event\ProjectBuildStartedEvent($instructions));
 
@@ -92,10 +96,14 @@ final class Generator
             $this->messenger->newLine();
 
             if (!$successful) {
-                $this->handleStepFailure($result, $step->getType(), $currentStep, $exception);
+                $restart = $this->handleStepFailure($result, $step->getType(), $currentStep, $exception);
 
                 break;
             }
+        }
+
+        if ($restart) {
+            return $this->run($targetDirectory);
         }
 
         $this->eventDispatcher->dispatch(new Event\ProjectBuildFinishedEvent($result));
@@ -120,7 +128,7 @@ final class Generator
         string $stepType,
         Step\StepInterface $step = null,
         Throwable $exception = null,
-    ): void {
+    ): bool {
         $this->messenger->error('Project generation failed. All processed steps will be reverted.');
         $this->messenger->newLine();
 
@@ -130,10 +138,18 @@ final class Generator
 
         $this->revertAllSteps($result);
 
-        $this->messenger->newLine();
+        if ([] !== $result->getAppliedSteps()) {
+            $this->messenger->newLine();
+        }
 
         if ($step instanceof Step\StoppableStepInterface && $step->isStopped()) {
-            return;
+            return false;
+        }
+
+        if ($this->messenger->confirmProjectRegeneration()) {
+            $this->messenger->newLine();
+
+            return true;
         }
 
         throw Exception\StepFailureException::create($stepType, $exception);

--- a/src/IO/Messenger.php
+++ b/src/IO/Messenger.php
@@ -215,6 +215,15 @@ final class Messenger
         return $this->getIO()->askConfirmation($label);
     }
 
+    public function confirmProjectRegeneration(): bool
+    {
+        $this->getIO()->write('If you want, you can restart project generation now.');
+
+        $label = self::decorateLabel('Restart?', 'Y', true, ['n']);
+
+        return $this->getIO()->askConfirmation($label);
+    }
+
     /**
      * @param int-mask-of<IO\IOInterface::*> $verbosity
      */

--- a/tests/src/Builder/Generator/GeneratorTest.php
+++ b/tests/src/Builder/Generator/GeneratorTest.php
@@ -27,7 +27,6 @@ use Composer\Package;
 use CPSIT\ProjectBuilder as Src;
 use CPSIT\ProjectBuilder\Tests;
 use PHPUnit\Framework;
-use Symfony\Component\Console;
 use Symfony\Component\Filesystem;
 
 use function dirname;
@@ -89,11 +88,46 @@ final class GeneratorTest extends Tests\ContainerAwareTestCase
     }
 
     #[Framework\Attributes\Test]
+    public function runRestartsProjectGenerationOnStepFailure(): void
+    {
+        self::$io->setUserInputs(['', '', '', 'yes', 'foo']);
+
+        self::assertCount(0, $this->eventListener->dispatchedEvents);
+
+        $actual = $this->subject->run($this->targetDirectory);
+
+        self::assertTrue($actual->isStepApplied('collectBuildInstructions'));
+        self::assertTrue($actual->isStepApplied('processSourceFiles'));
+        self::assertTrue($actual->isStepApplied('processSharedSourceFiles'));
+        self::assertTrue($actual->isStepApplied('generateBuildArtifact'));
+        self::assertTrue($actual->isStepApplied('mirrorProcessedFiles'));
+        self::assertTrue($actual->isMirrored());
+
+        $output = self::$io->getOutput();
+
+        self::assertStringContainsString('If you want, you can restart project generation now.', $output);
+        self::assertFileExists($this->targetDirectory.'/dummy.yaml');
+        self::assertStringEqualsFile($this->targetDirectory.'/dummy.yaml', 'name: "foo"'.PHP_EOL);
+
+        self::assertCount(10, $this->eventListener->dispatchedEvents);
+        self::assertInstanceOf(Src\Event\ProjectBuildStartedEvent::class, $this->eventListener->dispatchedEvents[0]);
+        self::assertInstanceOf(Src\Event\BuildStepProcessedEvent::class, $this->eventListener->dispatchedEvents[1]);
+        self::assertInstanceOf(Src\Event\BuildStepRevertedEvent::class, $this->eventListener->dispatchedEvents[2]);
+        self::assertInstanceOf(Src\Event\ProjectBuildStartedEvent::class, $this->eventListener->dispatchedEvents[3]);
+
+        for ($i = 4; $i <= 8; ++$i) {
+            self::assertInstanceOf(Src\Event\BuildStepProcessedEvent::class, $this->eventListener->dispatchedEvents[$i]);
+        }
+
+        self::assertInstanceOf(Src\Event\ProjectBuildFinishedEvent::class, $this->eventListener->dispatchedEvents[9]);
+    }
+
+    #[Framework\Attributes\Test]
     public function runRevertsAppliedStepsOnStepFailure(): void
     {
         $exception = null;
 
-        self::$io->setUserInputs([]);
+        self::$io->setUserInputs(['', '', '', 'no']);
 
         try {
             $this->subject->run($this->targetDirectory);
@@ -103,7 +137,7 @@ final class GeneratorTest extends Tests\ContainerAwareTestCase
         self::assertInstanceOf(Src\Exception\StepFailureException::class, $exception);
         self::assertSame(1652954290, $exception->getCode());
         self::assertSame('Running step "collectBuildInstructions" failed. All applied steps were reverted.', $exception->getMessage());
-        self::assertInstanceOf(Console\Exception\MissingInputException::class, $exception->getPrevious());
+        self::assertInstanceOf(Src\Exception\ValidationException::class, $exception->getPrevious());
 
         self::assertCount(1, $this->subject->getRevertedSteps());
         self::assertInstanceOf(

--- a/tests/src/Console/ApplicationTest.php
+++ b/tests/src/Console/ApplicationTest.php
@@ -158,7 +158,7 @@ final class ApplicationTest extends Tests\ContainerAwareTestCase
             $this->createTemplateSource(),
         ];
 
-        self::$io->setUserInputs(['', '']);
+        self::$io->setUserInputs(['', '', '', '', 'no']);
 
         self::assertSame(1, $this->subject->run());
         self::assertStringContainsString(

--- a/tests/src/IO/MessengerTest.php
+++ b/tests/src/IO/MessengerTest.php
@@ -122,6 +122,21 @@ final class MessengerTest extends Tests\ContainerAwareTestCase
         );
     }
 
+    #[Framework\Attributes\Test]
+    public function confirmProjectGenerationAsksForConfirmationAndReturnsResult(): void
+    {
+        self::$io->setUserInputs(['yes']);
+
+        self::assertTrue($this->subject->confirmProjectRegeneration());
+        self::assertStringContainsString(
+            implode(PHP_EOL, [
+                'If you want, you can restart project generation now.',
+                'Restart? [Y/n]',
+            ]),
+            self::$io->getOutput(),
+        );
+    }
+
     /**
      * @return Generator<string, array{Package\PackageInterface, string}>
      */


### PR DESCRIPTION
When a project generation step fails, the whole process fails due to a thrown `StepFailureException`. This can be very frustrating, because the whole process needs to be restarted from scratch.

For this, exceptions thrown during project generation are now caught and the user can decide whether he wants to restart project generation or not. If not, project generation is aborted like before.