### PR TITLE
[BUGFIX] Use console IO to enable probable VCS authentications

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -16,6 +16,7 @@ services:
       - '../src/Console/*'
       - '../src/DependencyInjection/*'
       - '../src/Event/*'
+      - '../src/IO/Console/TraceableConsoleIO.php'
       - '../src/Naming/NameVariantBuilder.php'
       - '../src/Resource/Local/ProcessedFile.php'
       - '../src/Template/TemplateSource.php'

--- a/src/IO/Console/TraceableConsoleIO.php
+++ b/src/IO/Console/TraceableConsoleIO.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/project-builder".
+ *
+ * Copyright (C) 2023 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\ProjectBuilder\IO\Console;
+
+use Composer\IO;
+
+/**
+ * TraceableConsoleIO.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+final class TraceableConsoleIO extends IO\ConsoleIO
+{
+    private bool $silenced = false;
+    private bool $outputWritten = false;
+
+    public function write($messages, $newline = true, $verbosity = self::NORMAL): void
+    {
+        if (!$this->silenced) {
+            parent::write($messages, $newline, $verbosity);
+        }
+
+        $this->outputWritten = true;
+    }
+
+    public function writeError($messages, $newline = true, $verbosity = self::NORMAL): void
+    {
+        if (!$this->silenced) {
+            parent::writeError($messages, $newline, $verbosity);
+        }
+
+        $this->outputWritten = true;
+    }
+
+    public function writeRaw($messages, $newline = true, $verbosity = self::NORMAL): void
+    {
+        if (!$this->silenced) {
+            parent::writeRaw($messages, $newline, $verbosity);
+        }
+
+        $this->outputWritten = true;
+    }
+
+    public function silence(): void
+    {
+        $this->silenced = true;
+    }
+
+    public function unsilence(): void
+    {
+        $this->silenced = false;
+    }
+
+    public function isOutputWritten(): bool
+    {
+        return $this->outputWritten;
+    }
+}

--- a/src/IO/Messenger.php
+++ b/src/IO/Messenger.php
@@ -227,14 +227,14 @@ final class Messenger
     /**
      * @param int-mask-of<IO\IOInterface::*> $verbosity
      */
-    public function progress(string $message, int $verbosity = IO\IOInterface::VERBOSE): void
+    public function progress(string $message, int $verbosity = IO\IOInterface::VERBOSE, bool $overwrite = false): void
     {
         if (!$this->checkVerbosity($verbosity)) {
             return;
         }
 
         $message = sprintf('<comment>%s</comment> ', rtrim($message));
-        $this->writeWithEmoji(Emoji::HourglassFlowingSand->value, $message);
+        $this->writeWithEmoji(Emoji::HourglassFlowingSand->value, $message, $overwrite);
 
         self::$lastProgressOutput = $message;
     }

--- a/src/Template/Provider/BaseProvider.php
+++ b/src/Template/Provider/BaseProvider.php
@@ -155,13 +155,13 @@ abstract class BaseProvider implements ProviderInterface
         }
 
         // Show installed template version
-        $this->messenger->clearLine();
         $this->messenger->progress(
             sprintf(
                 'Installing project template (<info>%s</info>)...',
                 $templateSource->getPackage()->getPrettyVersion(),
             ),
             ComposerIO\IOInterface::NORMAL,
+            true,
         );
         $this->messenger->done();
         $this->messenger->newLine();

--- a/src/Template/Provider/ComposerProvider.php
+++ b/src/Template/Provider/ComposerProvider.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace CPSIT\ProjectBuilder\Template\Provider;
 
 use Composer\Factory;
-use Composer\IO as ComposerIO;
 use CPSIT\ProjectBuilder\Exception;
 use CPSIT\ProjectBuilder\IO;
 use Symfony\Component\Console;
@@ -48,13 +47,24 @@ final class ComposerProvider extends BaseProvider implements CustomProviderInter
     ) {
         parent::__construct($messenger, $filesystem);
 
-        $this->io = new ComposerIO\ConsoleIO(
+        $this->io = new IO\Console\TraceableConsoleIO(
             new Console\Input\StringInput(''),
             Factory::createOutput(),
             new Console\Helper\HelperSet([
                 new Console\Helper\QuestionHelper(),
             ]),
         );
+    }
+
+    public function listTemplateSources(): array
+    {
+        $templateSources = parent::listTemplateSources();
+
+        if ($this->io instanceof IO\Console\TraceableConsoleIO && $this->io->isOutputWritten()) {
+            $this->messenger->newLine();
+        }
+
+        return $templateSources;
     }
 
     public function requestCustomOptions(IO\Messenger $messenger): void

--- a/tests/src/BufferedConsoleOutput.php
+++ b/tests/src/BufferedConsoleOutput.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/project-builder".
+ *
+ * Copyright (C) 2023 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\ProjectBuilder\Tests;
+
+use RuntimeException;
+use Symfony\Component\Console;
+
+use function fopen;
+use function fseek;
+use function is_string;
+use function stream_get_contents;
+
+/**
+ * BufferedConsoleOutput.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ *
+ * @internal
+ */
+final class BufferedConsoleOutput extends Console\Output\StreamOutput implements Console\Output\ConsoleOutputInterface
+{
+    /**
+     * @var resource
+     */
+    private $stream;
+    private Console\Output\OutputInterface $stderr;
+
+    public function __construct()
+    {
+        $this->stream = $this->createStream();
+        $this->stderr = new Console\Output\StreamOutput($this->createStream());
+
+        parent::__construct($this->stream, decorated: false);
+    }
+
+    public function getStream()
+    {
+        return $this->stream;
+    }
+
+    public function fetch(): string
+    {
+        fseek($this->stream, 0);
+
+        $output = stream_get_contents($this->stream);
+
+        if (!is_string($output)) {
+            throw new RuntimeException('The output stream cannot be processed.', 1687607309);
+        }
+
+        return $output;
+    }
+
+    public function getErrorOutput(): Console\Output\OutputInterface
+    {
+        return $this->stderr;
+    }
+
+    public function setErrorOutput(Console\Output\OutputInterface $error): void
+    {
+        $this->stderr = $error;
+    }
+
+    public function section(): Console\Output\ConsoleSectionOutput
+    {
+        $sections = [];
+
+        return new Console\Output\ConsoleSectionOutput(
+            $this->stream,
+            $sections,
+            $this->getVerbosity(),
+            $this->isDecorated(),
+            $this->getFormatter(),
+        );
+    }
+
+    /**
+     * @return resource
+     */
+    private function createStream()
+    {
+        $stream = fopen('php://temp', 'w+');
+
+        if (false === $stream) {
+            throw new RuntimeException('No output stream is available.', 1687607307);
+        }
+
+        return $stream;
+    }
+}

--- a/tests/src/IO/Console/TraceableConsoleIOTest.php
+++ b/tests/src/IO/Console/TraceableConsoleIOTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/project-builder".
+ *
+ * Copyright (C) 2023 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\ProjectBuilder\Tests\IO\Console;
+
+use CPSIT\ProjectBuilder as Src;
+use CPSIT\ProjectBuilder\Tests;
+use PHPUnit\Framework;
+use Symfony\Component\Console;
+
+/**
+ * TraceableConsoleIOTest.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+final class TraceableConsoleIOTest extends Framework\TestCase
+{
+    private Tests\BufferedConsoleOutput $output;
+    private Src\IO\Console\TraceableConsoleIO $subject;
+
+    protected function setUp(): void
+    {
+        $this->output = new Tests\BufferedConsoleOutput();
+        $this->subject = new Src\IO\Console\TraceableConsoleIO(
+            new Console\Input\StringInput(''),
+            $this->output,
+            new Console\Helper\HelperSet(),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function silenceSilencesOutput(): void
+    {
+        $this->subject->silence();
+
+        $this->subject->write('foo', false);
+
+        self::assertSame('', $this->output->fetch());
+        self::assertTrue($this->subject->isOutputWritten());
+    }
+
+    #[Framework\Attributes\Test]
+    public function unsilenceUnsilencesOutput(): void
+    {
+        $this->subject->silence();
+
+        $this->subject->write('foo', false);
+
+        $this->subject->unsilence();
+
+        $this->subject->write('baz', false);
+
+        self::assertSame('baz', $this->output->fetch());
+        self::assertTrue($this->subject->isOutputWritten());
+    }
+
+    #[Framework\Attributes\Test]
+    public function isOutputWrittenReturnsTrueIfMessagesWereWritten(): void
+    {
+        self::assertFalse($this->subject->isOutputWritten());
+
+        $this->subject->write('foo');
+
+        self::assertTrue($this->subject->isOutputWritten());
+    }
+
+    #[Framework\Attributes\Test]
+    public function isOutputWrittenReturnsTrueIfErrorMessagesWereWritten(): void
+    {
+        self::assertFalse($this->subject->isOutputWritten());
+
+        $this->subject->writeError('foo');
+
+        self::assertTrue($this->subject->isOutputWritten());
+    }
+
+    #[Framework\Attributes\Test]
+    public function isOutputWrittenReturnsTrueIfRawMessagesWereWritten(): void
+    {
+        self::assertFalse($this->subject->isOutputWritten());
+
+        $this->subject->writeRaw('foo');
+
+        self::assertTrue($this->subject->isOutputWritten());
+    }
+}

--- a/tests/src/Template/Provider/ComposerProviderTest.php
+++ b/tests/src/Template/Provider/ComposerProviderTest.php
@@ -28,6 +28,7 @@ use CPSIT\ProjectBuilder\Tests;
 use donatj\MockWebServer;
 use PHPUnit\Framework;
 use ReflectionObject;
+use ReflectionProperty;
 use Symfony\Component\Filesystem;
 
 /**
@@ -50,13 +51,14 @@ final class ComposerProviderTest extends Tests\ContainerAwareTestCase
         $this->server = new MockWebServer\MockWebServer();
         $this->server->start();
 
-        $this->overwriteIO();
         $this->acceptInsecureConnections();
     }
 
     #[Framework\Attributes\Test]
     public function requestCustomOptionsAsksAndAppliesBaseUrl(): void
     {
+        $this->overwriteIO();
+
         self::$io->setUserInputs(['https://example.com']);
 
         $this->subject->requestCustomOptions(self::$container->get('app.messenger'));
@@ -81,8 +83,27 @@ final class ComposerProviderTest extends Tests\ContainerAwareTestCase
     }
 
     #[Framework\Attributes\Test]
+    public function listTemplateSourcesAddsAdditionalEmptyLineOnWrittenOutput(): void
+    {
+        $serverUrl = sprintf('http://%s:%s', $this->server->getHost(), $this->server->getPort());
+        $io = $this->fetchIOViaReflection();
+
+        $this->subject->setUrl($serverUrl);
+
+        $io->silence();
+        $io->write('foo');
+
+        $this->subject->listTemplateSources();
+
+        self::assertTrue($io->isOutputWritten());
+        self::assertSame(PHP_EOL, self::$io->getOutput());
+    }
+
+    #[Framework\Attributes\Test]
     public function listTemplateSourcesConnectsToComposerHostToFetchAvailablePackages(): void
     {
+        $this->overwriteIO();
+
         $serverUrl = sprintf('http://%s:%s', $this->server->getHost(), $this->server->getPort());
 
         $this->subject->setUrl($serverUrl);
@@ -105,11 +126,27 @@ final class ComposerProviderTest extends Tests\ContainerAwareTestCase
         $this->setPropertyValueOnObject($this->subject, 'acceptInsecureConnections', true);
     }
 
+    private function fetchIOViaReflection(): Src\IO\Console\TraceableConsoleIO
+    {
+        $reflectionProperty = $this->getReflectionProperty($this->subject, 'io');
+        $io = $reflectionProperty->getValue($this->subject);
+
+        self::assertInstanceOf(Src\IO\Console\TraceableConsoleIO::class, $io);
+
+        return $io;
+    }
+
     private function setPropertyValueOnObject(object $object, string $propertyName, mixed $value): void
     {
-        $reflectionObject = new ReflectionObject($object);
-        $reflectionProperty = $reflectionObject->getProperty($propertyName);
+        $reflectionProperty = $this->getReflectionProperty($object, $propertyName);
         $reflectionProperty->setValue($object, $value);
+    }
+
+    private function getReflectionProperty(object $object, string $propertyName): ReflectionProperty
+    {
+        $reflectionObject = new ReflectionObject($object);
+
+        return $reflectionObject->getProperty($propertyName);
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
This PR fixes an issue where private VCS repositories could not be used due to authentication issues. Composer itself is able to prompt for username and password in case the current is not authenticated for a given VCS repository, but this is only possible in interactive mode. Since we used a buffered output for template installation, this was not possible before. Hence, this PR switches to a console IO for such operations to circumvent authentication issues.