### PR TITLE
[TASK] Harden return types for `InputReader::staticValue()`

### DIFF
--- a/src/IO/InputReader.php
+++ b/src/IO/InputReader.php
@@ -47,7 +47,7 @@ final class InputReader
     }
 
     /**
-     * @return ($required is true ? string : string|null)
+     * @return ($required is true ? non-empty-string : non-empty-string|null)
      *
      * @throws Exception\IOException
      */


### PR DESCRIPTION
Since `InputReader::staticValue()` always either returns a non-empty string or `null`, this can (and should) also be reflected within the annotated return types.