### PR TITLE
[TASK] Streamline `lint` and `fix` CGL scripts

### DIFF
--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -44,13 +44,13 @@ jobs:
 
       # Linting
       - name: Lint composer.json
-        run: composer lint:composer -- --dry-run
+        run: composer lint:composer
       - name: Lint Editorconfig
         run: composer lint:editorconfig
       - name: Lint JSON
         run: composer lint:json
       - name: Lint PHP
-        run: composer lint:php -- --dry-run --format=checkstyle | cs2pr
+        run: composer lint:php -- --format=checkstyle | cs2pr
 
       # SCA
       - name: SCA PHP

--- a/composer.json
+++ b/composer.json
@@ -95,17 +95,24 @@
 			"Composer\\Config::disableProcessTimeout",
 			"docker-compose -f docs/_build/docker-compose.yaml run --rm -it --service-ports serve"
 		],
+		"fix": [
+			"@fix:composer",
+			"@fix:editorconfig",
+			"@fix:php"
+		],
+		"fix:composer": "@composer normalize",
+		"fix:editorconfig": "@lint:editorconfig --fix",
+		"fix:php": "php-cs-fixer fix",
 		"lint": [
 			"@lint:composer",
-			"@lint:editorconfig:fix",
+			"@lint:editorconfig",
 			"@lint:json",
 			"@lint:php"
 		],
-		"lint:composer": "@composer normalize",
+		"lint:composer": "@fix:composer --dry-run",
 		"lint:editorconfig": "ec",
-		"lint:editorconfig:fix": "@lint:editorconfig --fix",
 		"lint:json": "jsonlint resources/config.schema.json",
-		"lint:php": "php-cs-fixer fix",
+		"lint:php": "@fix:php --dry-run",
 		"migration": [
 			"@migration:rector"
 		],

--- a/docs/contributing/workflow.md
+++ b/docs/contributing/workflow.md
@@ -41,7 +41,14 @@ composer lint:composer
 composer lint:editorconfig
 composer lint:json
 composer lint:php
-composer lint:yaml
+
+# Fix all CGL issues
+composer fix
+
+# Fix specific CGL issues
+composer fix:composer
+composer fix:editorconfig
+composer fix:php
 ```
 
 ### Run static code analysis


### PR DESCRIPTION
This PR harmonizes the usage of CGL scripts:

- `lint` scripts no longer fix CGL issues, but only print them to the console (dry-run mode)
- `fix` scripts actually fix CGL issues (like done before with `lint:<program>:fix`)