### PR TITLE
[FEATURE] Allow to skip confirmation to run configured command

### DIFF
--- a/docs/development/build-steps.md
+++ b/docs/development/build-steps.md
@@ -189,8 +189,9 @@ Place your command step after dependent steps have been executed. Multiple steps
 Please keep in mind that an already executed command cannot be reverted.
 
 ```{tip}
-Command execution needs to be confirmed by default. This can be skipped by setting
-`skipConfirmation: true` in step options.
+Users need to confirm each `runCommand` by default. You may, however, skip this confirmation and have the command run
+without user intervention by setting the `skipConfirmation: true` in the
+[step option configuration](https://github.com/CPS-IT/project-builder/blob/main/docs/development/configuration.md#structure-1).
 ```
 
 ### Show next steps

--- a/docs/development/build-steps.md
+++ b/docs/development/build-steps.md
@@ -188,6 +188,11 @@ Place your command step after dependent steps have been executed. Multiple steps
 
 Please keep in mind that an already executed command cannot be reverted.
 
+```{tip}
+Command execution needs to be confirmed by default. This can be skipped by setting
+`skipConfirmation: true` in step options.
+```
+
 ### Show next steps
 
 * Identifier: **`showNextSteps`**

--- a/docs/development/configuration.md
+++ b/docs/development/configuration.md
@@ -173,7 +173,8 @@ steps:
   - type: mirrorProcessedFiles
   - type: runCommand
     options:
-      command: 'composer install'
+      command: 'git init --initial-branch=main'
+      skipConfirmation: true
   - type: showNextSteps
     options:
       templateFile: templates/next-steps.html.twig

--- a/resources/config.schema.json
+++ b/resources/config.schema.json
@@ -303,6 +303,12 @@
 									"type": "string",
 									"title": "Shell command to be executed",
 									"description": "Specify the command that should be run in the project or temporary directory"
+								},
+								"skipConfirmation": {
+									"type": "boolean",
+									"title": "Do not ask for confirmation",
+									"description": "Skip user confirmation to run the configured command",
+									"default": false
 								}
 							},
 							"required": [

--- a/src/Builder/Config/ValueObject/StepOptions.php
+++ b/src/Builder/Config/ValueObject/StepOptions.php
@@ -39,6 +39,7 @@ final class StepOptions
         private readonly ?string $templateFile = null,
         private readonly ?string $artifactPath = null,
         private readonly ?string $command = null,
+        private readonly bool $skipConfirmation = false,
     ) {
     }
 
@@ -63,5 +64,10 @@ final class StepOptions
     public function getCommand(): ?string
     {
         return $this->command;
+    }
+
+    public function shouldSkipConfirmation(): bool
+    {
+        return $this->skipConfirmation;
     }
 }

--- a/src/Builder/Generator/Step/RunCommandStep.php
+++ b/src/Builder/Generator/Step/RunCommandStep.php
@@ -54,7 +54,7 @@ final class RunCommandStep extends AbstractStep implements StepInterface, Stoppa
     {
         $command = $this->config->getOptions()->getCommand() ?? throw InvalidConfigurationException::create('options.command');
 
-        if (!$this->messenger->confirmRunCommand($command)) {
+        if (!$this->config->getOptions()->shouldSkipConfirmation() && !$this->messenger->confirmRunCommand($command)) {
             $this->stopped = true;
 
             return false;

--- a/tests/src/Builder/Config/ConfigFactoryTest.php
+++ b/tests/src/Builder/Config/ConfigFactoryTest.php
@@ -91,6 +91,10 @@ final class ConfigFactoryTest extends Framework\TestCase
                     'runCommand',
                     new Src\Builder\Config\ValueObject\StepOptions(command: 'echo \'foo\''),
                 ),
+                new Src\Builder\Config\ValueObject\Step(
+                    'runCommand',
+                    new Src\Builder\Config\ValueObject\StepOptions(command: 'echo \'baz\'', skipConfirmation: true),
+                ),
             ],
             [
                 new Src\Builder\Config\ValueObject\Property(

--- a/tests/src/Builder/Generator/GeneratorTest.php
+++ b/tests/src/Builder/Generator/GeneratorTest.php
@@ -79,14 +79,14 @@ final class GeneratorTest extends Tests\ContainerAwareTestCase
         self::assertFileExists($this->targetDirectory.'/dummy.yaml');
         self::assertStringEqualsFile($this->targetDirectory.'/dummy.yaml', 'name: "foo"'.PHP_EOL);
 
-        self::assertCount(8, $this->eventListener->dispatchedEvents);
+        self::assertCount(9, $this->eventListener->dispatchedEvents);
         self::assertInstanceOf(Src\Event\ProjectBuildStartedEvent::class, $this->eventListener->dispatchedEvents[0]);
 
-        for ($i = 1; $i <= 6; ++$i) {
+        for ($i = 1; $i <= 7; ++$i) {
             self::assertInstanceOf(Src\Event\BuildStepProcessedEvent::class, $this->eventListener->dispatchedEvents[$i]);
         }
 
-        self::assertInstanceOf(Src\Event\ProjectBuildFinishedEvent::class, $this->eventListener->dispatchedEvents[7]);
+        self::assertInstanceOf(Src\Event\ProjectBuildFinishedEvent::class, $this->eventListener->dispatchedEvents[8]);
     }
 
     #[Framework\Attributes\Test]
@@ -111,17 +111,17 @@ final class GeneratorTest extends Tests\ContainerAwareTestCase
         self::assertFileExists($this->targetDirectory.'/dummy.yaml');
         self::assertStringEqualsFile($this->targetDirectory.'/dummy.yaml', 'name: "foo"'.PHP_EOL);
 
-        self::assertCount(11, $this->eventListener->dispatchedEvents);
+        self::assertCount(12, $this->eventListener->dispatchedEvents);
         self::assertInstanceOf(Src\Event\ProjectBuildStartedEvent::class, $this->eventListener->dispatchedEvents[0]);
         self::assertInstanceOf(Src\Event\BuildStepProcessedEvent::class, $this->eventListener->dispatchedEvents[1]);
         self::assertInstanceOf(Src\Event\BuildStepRevertedEvent::class, $this->eventListener->dispatchedEvents[2]);
         self::assertInstanceOf(Src\Event\ProjectBuildStartedEvent::class, $this->eventListener->dispatchedEvents[3]);
 
-        for ($i = 4; $i <= 9; ++$i) {
+        for ($i = 4; $i <= 10; ++$i) {
             self::assertInstanceOf(Src\Event\BuildStepProcessedEvent::class, $this->eventListener->dispatchedEvents[$i]);
         }
 
-        self::assertInstanceOf(Src\Event\ProjectBuildFinishedEvent::class, $this->eventListener->dispatchedEvents[10]);
+        self::assertInstanceOf(Src\Event\ProjectBuildFinishedEvent::class, $this->eventListener->dispatchedEvents[11]);
     }
 
     #[Framework\Attributes\Test]

--- a/tests/src/Builder/Generator/Step/RunCommandStepTest.php
+++ b/tests/src/Builder/Generator/Step/RunCommandStepTest.php
@@ -77,6 +77,31 @@ final class RunCommandStepTest extends Tests\ContainerAwareTestCase
     }
 
     #[Framework\Attributes\Test]
+    public function runExecutesCommandWithoutConfirmationIfSKipConfirmationIsConfigured(): void
+    {
+        $this->subject->setConfig(
+            new Src\Builder\Config\ValueObject\Step(
+                Src\Builder\Generator\Step\RunCommandStep::getType(),
+                new Src\Builder\Config\ValueObject\StepOptions(
+                    command: 'echo \'foo\'',
+                    skipConfirmation: true,
+                ),
+            ),
+        );
+
+        $workingDirectory = $this->result->getWrittenDirectory();
+
+        $fileSystem = new Filesystem\Filesystem();
+        if (!$fileSystem->exists($workingDirectory)) {
+            $fileSystem->mkdir($workingDirectory);
+        }
+
+        self::assertTrue($this->subject->run($this->result));
+        self::assertFalse($this->subject->isStopped());
+        self::assertStringNotContainsString('Do you wish to run this command?', self::$io->getOutput());
+    }
+
+    #[Framework\Attributes\Test]
     public function negatedQuestionForExecutionResultsInStoppedRun(): void
     {
         $this->subject->setConfig(

--- a/tests/src/Fixtures/Templates/json-template/config.json
+++ b/tests/src/Fixtures/Templates/json-template/config.json
@@ -71,6 +71,13 @@
 			"options": {
 				"command": "echo 'foo'"
 			}
+		},
+		{
+			"type": "runCommand",
+			"options": {
+				"command": "echo 'baz'",
+				"skipConfirmation": true
+			}
 		}
 	],
 	"properties": [

--- a/tests/src/Fixtures/Templates/yaml-template/config.yaml
+++ b/tests/src/Fixtures/Templates/yaml-template/config.yaml
@@ -37,6 +37,10 @@ steps:
   - type: runCommand
     options:
       command: "echo 'foo'"
+  - type: runCommand
+    options:
+      command: "echo 'baz'"
+      skipConfirmation: true
 
 properties:
   - identifier: foo


### PR DESCRIPTION
This PR extends the new `runCommand` step by a step option `skipConfirmation`. It defaults to `false`. When set to `true`, the user confirmation before running the configured command is skipped.