### PR TITLE
[FEATURE] Use timestamps for build artifact versions

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -23,7 +23,7 @@ services:
 
   CPSIT\ProjectBuilder\Builder\ArtifactReader:
     arguments:
-      $migrations: !tagged_iterator artifact.migration
+      $migrations: !tagged_iterator { tag: artifact.migration, default_index_method: getVersion }
 
   CPSIT\ProjectBuilder\Builder\Config\Config:
     alias: 'app.config'

--- a/resources/build-artifact.schema.json
+++ b/resources/build-artifact.schema.json
@@ -31,10 +31,7 @@
 				"version": {
 					"type": "integer",
 					"title": "Version of build artifact when originally dumped",
-					"enum": [
-						1
-					],
-					"default": 1
+					"const": 1679497137
 				},
 				"path": {
 					"type": "string",

--- a/src/Builder/Artifact/Migration/Migration.php
+++ b/src/Builder/Artifact/Migration/Migration.php
@@ -40,7 +40,5 @@ interface Migration
      */
     public function migrate(array $artifact): array;
 
-    public static function getSourceVersion(): int;
-
-    public static function getTargetVersion(): int;
+    public static function getVersion(): int;
 }

--- a/src/Builder/Artifact/Migration/Migration1679497137.php
+++ b/src/Builder/Artifact/Migration/Migration1679497137.php
@@ -31,6 +31,8 @@ namespace CPSIT\ProjectBuilder\Builder\Artifact\Migration;
  */
 final class Migration1679497137 extends BaseMigration
 {
+    public const VERSION = 1679497137;
+
     public function migrate(array $artifact): array
     {
         // Silent migration from artifact.file to artifact.path
@@ -44,13 +46,8 @@ final class Migration1679497137 extends BaseMigration
         return $artifact;
     }
 
-    public static function getSourceVersion(): int
+    public static function getVersion(): int
     {
-        return 1;
-    }
-
-    public static function getTargetVersion(): int
-    {
-        return 1;
+        return self::VERSION;
     }
 }

--- a/src/Builder/ArtifactGenerator.php
+++ b/src/Builder/ArtifactGenerator.php
@@ -40,7 +40,7 @@ use function getenv;
  */
 final class ArtifactGenerator
 {
-    public const VERSION = 1;
+    public const VERSION = Artifact\Migration\Migration1679497137::VERSION;
 
     public function build(
         Finder\SplFileInfo $file,

--- a/src/Builder/ArtifactReader.php
+++ b/src/Builder/ArtifactReader.php
@@ -134,6 +134,8 @@ final class ArtifactReader
             }
         }
 
+        Helper\ArrayHelper::setValueByPath($artifact, 'artifact.version', ArtifactGenerator::VERSION);
+
         return $artifact;
     }
 

--- a/src/Builder/ArtifactReader.php
+++ b/src/Builder/ArtifactReader.php
@@ -30,18 +30,13 @@ use CPSIT\ProjectBuilder\Paths;
 use CuyZ\Valinor;
 use DateTimeInterface;
 use Opis\JsonSchema;
-use ReflectionObject;
 use Symfony\Component\Filesystem;
 
 use function array_filter;
-use function array_values;
 use function file_get_contents;
-use function implode;
 use function is_array;
 use function is_numeric;
 use function json_decode;
-use function ksort;
-use function range;
 
 /**
  * ArtifactReader.
@@ -54,20 +49,14 @@ final class ArtifactReader
     private readonly Valinor\Mapper\TreeMapper $mapper;
 
     /**
-     * @var list<Artifact\Migration\Migration>
-     */
-    private readonly array $migrations;
-
-    /**
      * @param iterable<Artifact\Migration\Migration> $migrations
      */
     public function __construct(
-        iterable $migrations,
+        private readonly iterable $migrations,
         private readonly Filesystem\Filesystem $filesystem,
         private readonly Json\SchemaValidator $schemaValidator,
     ) {
         $this->mapper = $this->createMapper();
-        $this->migrations = $this->orderMigrations($migrations);
     }
 
     /**
@@ -138,13 +127,10 @@ final class ArtifactReader
     private function performMigrations(array $artifact): array
     {
         $artifactVersion = $this->determineArtifactVersion($artifact);
-        $migrationPath = range($artifactVersion, ArtifactGenerator::VERSION);
 
-        foreach ($migrationPath as $sourceVersion) {
-            foreach ($this->migrations as $migration) {
-                if ($sourceVersion === $migration::getSourceVersion()) {
-                    $artifact = $migration->migrate($artifact);
-                }
+        foreach ($this->migrations as $migration) {
+            if ($migration::getVersion() > $artifactVersion) {
+                $artifact = $migration->migrate($artifact);
             }
         }
 
@@ -174,29 +160,5 @@ final class ArtifactReader
             ->supportDateFormats(DateTimeInterface::ATOM)
             ->mapper()
         ;
-    }
-
-    /**
-     * @param iterable<Artifact\Migration\Migration> $migrations
-     *
-     * @return list<Artifact\Migration\Migration>
-     */
-    private function orderMigrations(iterable $migrations): array
-    {
-        $prefixedMigrations = [];
-
-        foreach ($migrations as $migration) {
-            $reflectionObject = new ReflectionObject($migration);
-            $migrationIdentifier = implode('_', [
-                $migration::getSourceVersion(),
-                $migration::getTargetVersion(),
-                $reflectionObject->getShortName(),
-            ]);
-            $prefixedMigrations[$migrationIdentifier] = $migration;
-        }
-
-        ksort($prefixedMigrations);
-
-        return array_values($prefixedMigrations);
     }
 }

--- a/tests/src/Fixtures/DummyMigration.php
+++ b/tests/src/Fixtures/DummyMigration.php
@@ -49,13 +49,9 @@ final class DummyMigration extends Builder\Artifact\Migration\BaseMigration
         return $artifact;
     }
 
-    public static function getSourceVersion(): int
+    public static function getVersion(): int
     {
-        return 1;
-    }
-
-    public static function getTargetVersion(): int
-    {
-        return 2;
+        // Make sure to always perform this migration
+        return PHP_INT_MAX;
     }
 }


### PR DESCRIPTION
This PR changes the logic of build artifact versioning a little bit. Artifacts are no longer versioned by incrementing the previous version. Instead, each migration provides a unique version identifier. This, in turn, is then used as version of the build artifact. In fact, the version of the latest migration represents the version of a build artifact. If a build artifact's version does not match the latest available migration version, it is automatically migrated during parsing by `ArtifactReader::fromFile()`.