### PR TITLE
[BUGFIX] Write build artifact to target directory

### DIFF
--- a/src/Builder/Generator/Step/GenerateBuildArtifactStep.php
+++ b/src/Builder/Generator/Step/GenerateBuildArtifactStep.php
@@ -93,6 +93,9 @@ final class GenerateBuildArtifactStep extends AbstractStep implements StoppableS
     {
         $artifactPath = $this->config->getOptions()->getArtifactPath() ?? self::DEFAULT_ARTIFACT_PATH;
 
-        return Helper\FilesystemHelper::createFileObject($buildResult->getWrittenDirectory(), $artifactPath);
+        return Helper\FilesystemHelper::createFileObject(
+            $buildResult->getInstructions()->getTargetDirectory(),
+            $artifactPath,
+        );
     }
 }

--- a/tests/src/Builder/Generator/GeneratorTest.php
+++ b/tests/src/Builder/Generator/GeneratorTest.php
@@ -134,7 +134,7 @@ final class GeneratorTest extends Tests\ContainerAwareTestCase
     {
         $listener = function (Src\Event\ProjectBuildStartedEvent $event): void {
             $this->filesystem->dumpFile(
-                Filesystem\Path::join($event->getInstructions()->getTemporaryDirectory(), 'foo.json'),
+                Filesystem\Path::join($event->getInstructions()->getTargetDirectory(), 'foo.json'),
                 '{}',
             );
         };

--- a/tests/src/Builder/Generator/Step/GenerateBuildArtifactStepTest.php
+++ b/tests/src/Builder/Generator/Step/GenerateBuildArtifactStepTest.php
@@ -48,10 +48,10 @@ final class GenerateBuildArtifactStepTest extends Tests\ContainerAwareTestCase
         $this->subject = self::$container->get(Src\Builder\Generator\Step\GenerateBuildArtifactStep::class);
         $this->filesystem = self::$container->get(Filesystem\Filesystem::class);
         $this->buildResult = new Src\Builder\BuildResult(
-            new Src\Builder\BuildInstructions(self::$config, 'foo'),
+            new Src\Builder\BuildInstructions(self::$config, Src\Helper\FilesystemHelper::getNewTemporaryDirectory()),
         );
         $this->artifactFile = Src\Helper\FilesystemHelper::createFileObject(
-            $this->buildResult->getWrittenDirectory(),
+            $this->buildResult->getInstructions()->getTargetDirectory(),
             '.build/build-artifact.json',
         );
     }


### PR DESCRIPTION
This PR fixes an issue with build artifacts to explicitly write them to the target directory.