### PR TITLE
[FEATURE] Support expression languages providers for autoconfiguration

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -46,6 +46,9 @@ return static function (
     $container->registerForAutoconfiguration(Builder\Writer\WriterInterface::class)
         ->addTag('builder.writer')
     ;
+    $container->registerForAutoconfiguration(ExpressionLanguage\ExpressionFunctionProviderInterface::class)
+        ->addTag('expression_language.provider')
+    ;
     $container->registerForAutoconfiguration(Builder\Generator\Step\Interaction\InteractionInterface::class)
         ->addTag('generator.interaction')
     ;
@@ -76,6 +79,12 @@ return static function (
         new CompilerPass\EventListenerPass(
             'event.listener',
             EventDispatcher\EventDispatcherInterface::class,
+        ),
+    );
+    $container->addCompilerPass(
+        new CompilerPass\ExpressionLanguageProviderPass(
+            'expression_language.provider',
+            ExpressionLanguage\ExpressionLanguage::class,
         ),
     );
 

--- a/docs/development/configuration.md
+++ b/docs/development/configuration.md
@@ -213,6 +213,73 @@ properties:
           - type: email
 ```
 
+### Twig integration
+
+Some configuration parts may be configured as Twig templates. For example, the
+`defaultValue` option of a configured property may contain the processed value
+of a previously added property:
+
+```{code-block} yaml
+:linenos:
+:caption: config.yaml
+:emphasize-lines: 18
+
+properties:
+  - identifier: project
+    name: Project
+    properties:
+      - identifier: name
+        name: Name
+        type: staticValue
+        validators:
+          - type: notEmpty
+      - identifier: vendor
+        name: Vendor
+        type: staticValue
+        validators:
+          - type: notEmpty
+      - identifier: package_name
+        name: Package name
+        type: staticValue
+        defaultValue: '{{ project.vendor | slugify }}/{{ project.name | slugify }}'
+        validators:
+          - type: notEmpty
+```
+
+The following configuration options are currently processed by the Twig renderer:
+
+* `steps.*.options.fileConditions.*.target`
+* `properties.*.properties.*.defaultValue`
+* `properties.*.properties.*.options.*.value`
+
+### Symfony Expression Language integration
+
+Several configuration options use conditions to determine whether a property or step
+should be applied. All used conditions are parsed by the [Symfony Expression Language][5].
+
+Example:
+
+```{code-block} yaml
+:linenos:
+:caption: config.yaml
+:emphasize-lines: 6
+
+steps:
+  - type: processSharedSourceFiles
+    options:
+      fileConditions:
+        - path: composer.json
+          if: 'features["composer"] == true'
+```
+
+The following configuration options are currently evaluated by the Symfony Expression
+Language:
+
+* `steps.*.options.fileConditions.*.if`
+* `properties.*.if`
+* `properties.*.properties.*.if`
+* `properties.*.properties.*.options.*.if`
+
 ### Mapping and hydration
 
 Config files are located by the [`ConfigReader`](https://github.com/CPS-IT/project-builder/blob/main/src/Builder/Config/ConfigReader.php)
@@ -338,3 +405,4 @@ my-fancy-shared-resource
 [2]: https://github.com/justinrainbow/json-schema
 [3]: https://packagist.org/packages/oomphinc/composer-installers-extender
 [4]: https://github.com/composer/satis
+[5]: https://symfony.com/doc/current/components/expression_language.html

--- a/docs/development/dependency-injection.md
+++ b/docs/development/dependency-injection.md
@@ -11,14 +11,15 @@ bootstrapping. It depends on the following resources:
 
 Some special services exist that are tagged during container build-time:
 
-| Tag name         | Resource                                                                                                                                   |
-|------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
-| `builder.writer` | [`Builder\Writer\WriterInterface`](https://github.com/CPS-IT/project-builder/blob/main/src/Builder/Writer/WriterInterface.php)             |
-| `event.listener` | –                                                                                                                                          |
-| `generator.step` | [`Builder\Generator\Step\StepInterface`](https://github.com/CPS-IT/project-builder/blob/main/src/Builder/Generator/Step/StepInterface.php) |
-| `io.validator`   | [`IO\Validator\ValidatorInterface`](https://github.com/CPS-IT/project-builder/blob/main/src/IO/Validator/ValidatorInterface.php)           |
-| `twig.filter`    | [`Twig\Filter\TwigFilterInterface`](https://github.com/CPS-IT/project-builder/blob/main/src/Twig/Filter/TwigFilterInterface.php)           |
-| `twig.function`  | [`Twig\Func\TwigFunctionInterface`](https://github.com/CPS-IT/project-builder/blob/main/src/Twig/Func/TwigFunctionInterface.php)           |
+| Tag name                       | Resource                                                                                                                                   |
+|--------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| `builder.writer`               | [`Builder\Writer\WriterInterface`](https://github.com/CPS-IT/project-builder/blob/main/src/Builder/Writer/WriterInterface.php)             |
+| `event.listener`               | –                                                                                                                                          |
+| `expression_language.provider` | `Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface`                                                                 |
+| `generator.step`               | [`Builder\Generator\Step\StepInterface`](https://github.com/CPS-IT/project-builder/blob/main/src/Builder/Generator/Step/StepInterface.php) |
+| `io.validator`                 | [`IO\Validator\ValidatorInterface`](https://github.com/CPS-IT/project-builder/blob/main/src/IO/Validator/ValidatorInterface.php)           |
+| `twig.filter`                  | [`Twig\Filter\TwigFilterInterface`](https://github.com/CPS-IT/project-builder/blob/main/src/Twig/Filter/TwigFilterInterface.php)           |
+| `twig.function`                | [`Twig\Func\TwigFunctionInterface`](https://github.com/CPS-IT/project-builder/blob/main/src/Twig/Func/TwigFunctionInterface.php)           |
 
 ## Synthetic services
 

--- a/rector.php
+++ b/rector.php
@@ -46,6 +46,7 @@ return static function (RectorConfig $rectorConfig): void {
             __DIR__.'/src/Console/Simulation.php',
             __DIR__.'/src/DependencyInjection/CompilerPass/ContainerBuilderDebugDumpPass.php',
             __DIR__.'/src/DependencyInjection/CompilerPass/EventListenerPass.php',
+            __DIR__.'/src/DependencyInjection/CompilerPass/ExpressionLanguageProviderPass.php',
             __DIR__.'/src/DependencyInjection/CompilerPass/FactoryServicesPass.php',
             __DIR__.'/src/DependencyInjection/CompilerPass/PublicServicePass.php',
             __DIR__.'/src/DependencyInjection/ContainerFactory.php',

--- a/src/DependencyInjection/CompilerPass/ExpressionLanguageProviderPass.php
+++ b/src/DependencyInjection/CompilerPass/ExpressionLanguageProviderPass.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/project-builder".
+ *
+ * Copyright (C) 2023 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\ProjectBuilder\DependencyInjection\CompilerPass;
+
+use CPSIT\ProjectBuilder\Exception;
+use Symfony\Component\DependencyInjection;
+
+/**
+ * ExpressionLanguageProviderPass.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ *
+ * @internal
+ *
+ * @codeCoverageIgnore
+ */
+final class ExpressionLanguageProviderPass implements DependencyInjection\Compiler\CompilerPassInterface
+{
+    public function __construct(
+        private readonly string $tagName,
+        private readonly string $expressionLanguageId,
+    ) {
+    }
+
+    public function process(DependencyInjection\ContainerBuilder $container): void
+    {
+        $serviceIds = $container->findTaggedServiceIds($this->tagName);
+
+        if (!$container->hasDefinition($this->expressionLanguageId)) {
+            throw Exception\ShouldNotHappenException::create();
+        }
+
+        $expressionLanguageService = $container->findDefinition($this->expressionLanguageId);
+
+        foreach ($serviceIds as $serviceId => $tags) {
+            if ($container->hasDefinition($serviceId)) {
+                $expressionLanguageService->addMethodCall('registerProvider', [
+                    new DependencyInjection\Reference($serviceId),
+                ]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
With this PR, custom expression function providers for Symfony Expression Language are now autoconfigured when building the service container. This allows template authors to provide custom expression functions and to use them in template configuration.