### PR TITLE
[TASK] Add Composer 2.6 to test matrix

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         php-version: ["8.1", "8.2"]
-        composer-version: ["2.1", "2.2", "2.3", "2.4", "2.5"]
+        composer-version: ["2.1", "2.2", "2.3", "2.4", "2.5", "2.6"]
         dependencies: ["highest", "lowest"]
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Composer 2.6 was released recently and we should make sure the project builder supports the latest version.

Resolves: #299