### PR TITLE
[DOCS] Show more configuration options in config example

### DIFF
--- a/docs/development/configuration.md
+++ b/docs/development/configuration.md
@@ -165,8 +165,9 @@ steps:
         - path: composer.json.twig
           if: 'features["composer"]'
         # ... or use static files
-        - path: phpstan.neon
-          if: 'features["phpstan"]'
+        - path: example-v3.conf
+          if: 'features["example"] && example["version"] == "3"'
+          target: example.conf
   - type: processSharedSourceFiles
     options:
       fileConditions:

--- a/docs/development/configuration.md
+++ b/docs/development/configuration.md
@@ -159,11 +159,20 @@ steps:
   - type: installComposerDependencies
   - type: collectBuildInstructions
   - type: processSourceFiles
+    options:
+      fileConditions:
+        # You can define a Twig template to render...
+        - path: composer.json.twig
+          if: 'features["composer"]'
+        # ... or use static files
+        - path: phpstan.neon
+          if: 'features["phpstan"]'
   - type: processSharedSourceFiles
     options:
       fileConditions:
-        - path: composer.json
-          if: 'false'
+        # Use Symfony Expression Language to define file conditions
+        - path: phpunit.xml
+          if: 'features["phpunit"]'
         # Mirror an entire directory
         - path: 'source-dir/*'
           target: 'target-dir/*'
@@ -199,6 +208,21 @@ properties:
             options:
               pattern: '/^[a-zA-Z]+$/'
               errorMessage: 'The project name should consist of letters only.'
+
+  # Features
+  - identifier: features
+    name: Features
+    properties:
+      - identifier: composer
+        name: Enable <comment>Composer</comment> support?
+        type: question
+        defaultValue: true
+      - identifier: phpstan
+        name: Do you need <comment>PHPStan</comment> support?
+        type: question
+      - identifier: phpunit
+        name: Do you want to run tests with <comment>PHPUnit</comment>?
+        type: question
 
   # Author
   - identifier: author


### PR DESCRIPTION
The example used to demonstrate some basic configuration options is pretty limited. Especially when it comes to the various opportunities to define file conditions, the example is not very helpful and hard to understand for new contributors and template developers.

This PR aims to provide a better overview about possible configuration options. It introduces some new and more real-world config properties and demonstrates how to properly use them in combination with file conditions.