### PR TITLE
[TASK] Include OCI labels in generated Docker image

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -55,3 +55,4 @@ jobs:
           build-args: |
             PROJECT_BUILDER_VERSION=${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '0.0.0' }}
           tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
All OCI labels generated during Docker image metadata generation are now passed to the Docker build & push job.