### PR TITLE
[BUGFIX] Allow manual Docker builds

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   deploy:
-    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -16,9 +15,9 @@ jobs:
 
       # Check if tag is valid
       - name: Check tag
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         run: |
           if ! [[ ${{ github.ref }} =~ ^refs/tags/[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}$ ]]; then
-            echo ":rotating_light: This job can be executed only for tags." >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
 
@@ -54,5 +53,5 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           build-args: |
-            PROJECT_BUILDER_VERSION=${{ github.ref_name }}
+            PROJECT_BUILDER_VERSION=${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '0.0.0' }}
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
The workflow for Docker builds is able to be run on workflow dispatch. However, the actual job requires a tag to be set for the current execution. This check is now removed to be able to run manual Docker builds using workflow dispatch.