### PR TITLE
[TASK] Cache Docker builds in GitHub Actions cache

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -56,3 +56,5 @@ jobs:
             PROJECT_BUILDER_VERSION=${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '0.0.0' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
This PR extends the Docker build job to use GitHub Actions cache.