### PR TITLE
[FEATURE] Publish Docker image at GitHub Container Registry

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -26,7 +26,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: cpsit/project-builder
+          images: |
+            cpsit/project-builder
+            ghcr.io/cps-it/project-builder
           tags: |
             type=raw,value=latest,enable=${{ github.event_name != 'workflow_dispatch' }}
             type=semver,pattern={{version}}
@@ -44,6 +46,14 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Login at GitHub container registry
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       # Build and push image
       - name: Build and push

--- a/docs/usage/docker.md
+++ b/docs/usage/docker.md
@@ -7,6 +7,13 @@
 {octicon}`link-external;1em;sd-mr-1` View image on Docker Hub
 ```
 
+```{button-link} https://github.com/CPS-IT/project-builder/pkgs/container/project-builder
+:color: primary
+:outline:
+
+{octicon}`link-external;1em;sd-mr-1` View image on GitHub Container Registry
+```
+
 ## Requirements
 
 * [Docker][1]
@@ -17,7 +24,11 @@ As an alternative to the usage with Composer, there's also a ready-to-use
 [Docker image][2]:
 
 ```bash
+# Docker Hub
 docker run --rm -it -v <target-dir>:/app cpsit/project-builder
+
+# GitHub Container Registry
+docker run --rm -it -v <target-dir>:/app ghcr.io/cps-it/project-builder
 ```
 
 Replace `<target-dir>` with an absolute or relative path to the directory


### PR DESCRIPTION
With this PR, GitHub Container Registry is now used as an alternative provider for the Docker image.

```bash
docker run --rm -it -v <target-dir>:/app ghcr.io/cps-it/project-builder
```