### PR TITLE
[TASK] Use up-to-date GitHub action for docker layer caching

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -126,7 +126,7 @@ jobs:
 
       # Handle Docker image layer cache
       - name: Handle Docker cache
-        uses: satackey/action-docker-layer-caching@v0.0.11
+        uses: jpribyl/action-docker-layer-caching@v0.1.1
         continue-on-error: true
 
       # Run Docker tests


### PR DESCRIPTION
This PR replaces the `satackey/action-docker-layer-caching` action by `jpribyl/action-docker-layer-caching` since the former seems to be no longer maintained (see satackey/action-docker-layer-caching#347).