### PR TITLE
[BUGFIX] Correctly remove twig file extension with target file given

### DIFF
--- a/src/Builder/Writer/TemplateWriter.php
+++ b/src/Builder/Writer/TemplateWriter.php
@@ -55,7 +55,7 @@ final class TemplateWriter implements WriterInterface
         $renderResult = $renderer->render($instructions, $file->getFilename(), $variables);
         $targetFile = Helper\FilesystemHelper::createFileObject(
             $instructions->getTemporaryDirectory(),
-            $targetFile ?? (string) preg_replace('/\.twig$/', '', $file->getRelativePathname()),
+            (string) preg_replace('/\.twig$/', '', $targetFile ?? $file->getRelativePathname()),
         );
 
         $this->filesystem->dumpFile($targetFile->getPathname(), $renderResult);

--- a/tests/src/Builder/Writer/TemplateWriterTest.php
+++ b/tests/src/Builder/Writer/TemplateWriterTest.php
@@ -95,7 +95,7 @@ final class TemplateWriterTest extends Tests\ContainerAwareTestCase
         $file = new Finder\SplFileInfo($templateFile, dirname($templateFile), basename($templateFile));
 
         $expected = $instructions->getTemporaryDirectory().'/overrides/dump.json';
-        $actual = $this->subject->write($instructions, $file, 'overrides/dump.json', ['bar' => 'bar']);
+        $actual = $this->subject->write($instructions, $file, 'overrides/dump.json.twig', ['bar' => 'bar']);
 
         self::assertSame($expected, $actual->getPathname());
         self::assertFileExists($expected);


### PR DESCRIPTION
This PR fixes an edge-case issue with `TemplateWriter`: If a target file with `.twig` file extension was given, it was not removed. This only happened if the target file was calculated from the given source file. The appropriate test case did not catch this case, because it was not created from a realistic scenario. It is now fixed as well.

Resolves: #392