### PR TITLE
[TASK] Explicitly set PHP version constraint for Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,8 @@
 	],
 	"assignees": [
 		"eliashaeussler"
-	]
+	],
+	"constraints": {
+		"php": "8.1.*"
+	}
 }


### PR DESCRIPTION
This PR explicitly configures the `php` version constraint in `renovate.json`. This is required to avoid package updates without support for PHP 8.1, since Renovate by default does not select the lowest compatible PHP version, see renovatebot/renovate#13637.