### PR TITLE
[BUGFIX] Disallow symfony/console 7.x for the time being

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 		"psr/http-message": "^1.0 || ^2.0",
 		"sebastianfeldmann/cli": "^3.4",
 		"symfony/config": "^5.4 || ^6.0 || ^7.0",
-		"symfony/console": "^5.4 || ^6.0 || ^7.0",
+		"symfony/console": "^5.4 || ^6.0",
 		"symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
 		"symfony/event-dispatcher": "^5.4 || ^6.0 || ^7.0",
 		"symfony/expression-language": "^5.4 || ^6.0 || ^7.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6c8a4dce238cc34ef2f302972e09d2ae",
+    "content-hash": "75d9bd98aad0bb01cda4cbe5058b094d",
     "packages": [
         {
             "name": "cocur/slugify",


### PR DESCRIPTION
Composer < 2.7 is not and won't ever be compatible with `symfony/console` 7.x (see https://github.com/composer/composer/issues/11741#issuecomment-1847572878). An appropriate "fix" was added with Composer 2.6.6 where `symfony/console` 7.x was explicitly disallowed. Since we allow `symfony/console` 7.x in Composer environments which are most likely not compatible with said version, we now explicitly remove support for `symfony/console` 7.x. We'll re-add it later if most people have upgraded to a more recent version where stable support for `symfony/console` 7.x is guaranteed.