### PR TITLE
[FEATURE] Allow commands to fail using configuration

### DIFF
--- a/docs/development/build-steps.md
+++ b/docs/development/build-steps.md
@@ -193,7 +193,7 @@ Users need to confirm the execution of each `runCommand` by default. You may, ho
 confirmation and have the command run without user intervention by setting the `skipConfirmation: true`
 in the [step option configuration](configuration.md#structure).
 
-Additionally, you can opt to ignore the result of a potentially failing command run with `allowFailures: true`
+Additionally, you can opt to ignore the result of a potentially failing command run with `allowFailure: true`
 to ensure the project generation would not abort because of that failure.
 ```
 

--- a/docs/development/build-steps.md
+++ b/docs/development/build-steps.md
@@ -189,9 +189,12 @@ Place your command step after dependent steps have been executed. Multiple steps
 Please keep in mind that an already executed command cannot be reverted.
 
 ```{tip}
-Users need to confirm each `runCommand` by default. You may, however, skip this confirmation and have the command run
-without user intervention by setting the `skipConfirmation: true` in the
-[step option configuration](configuration.md#structure).
+Users need to confirm the execution of each `runCommand` by default. You may, however, skip this
+confirmation and have the command run without user intervention by setting the `skipConfirmation: true`
+in the [step option configuration](configuration.md#structure).
+
+Additionally, you can opt to ignore the result of a potentially failing command run with `allowFailures: true`
+to ensure the project generation would not abort because of that failure.
 ```
 
 ### Show next steps

--- a/docs/development/build-steps.md
+++ b/docs/development/build-steps.md
@@ -190,7 +190,7 @@ Please keep in mind that an already executed command cannot be reverted.
 
 ```{tip}
 Users need to confirm the execution of each `runCommand` by default. You may, however, skip this
-confirmation and have the command run without user intervention by setting the `skipConfirmation: true`
+confirmation and have the command run without user intervention by setting `skipConfirmation: true`
 in the [step option configuration](configuration.md#structure).
 
 Additionally, you can opt to ignore the result of a potentially failing command run with `allowFailure: true`

--- a/docs/development/configuration.md
+++ b/docs/development/configuration.md
@@ -185,6 +185,7 @@ steps:
     options:
       command: 'git init --initial-branch=main'
       skipConfirmation: true
+      allowFailures: true
   - type: showNextSteps
     options:
       templateFile: templates/next-steps.html.twig

--- a/docs/development/configuration.md
+++ b/docs/development/configuration.md
@@ -185,7 +185,7 @@ steps:
     options:
       command: 'git init --initial-branch=main'
       skipConfirmation: true
-      allowFailures: true
+      allowFailure: true
   - type: showNextSteps
     options:
       templateFile: templates/next-steps.html.twig

--- a/resources/config.schema.json
+++ b/resources/config.schema.json
@@ -310,9 +310,9 @@
 									"description": "Skip user confirmation to run the configured command",
 									"default": false
 								},
-								"allowFailures": {
+								"allowFailure": {
 									"type": "boolean",
-									"title": "Allow command execution failures",
+									"title": "Allow command execution failure",
 									"description": "Ignore errors occurred during command execution and continue as normal",
 									"default": false
 								}

--- a/resources/config.schema.json
+++ b/resources/config.schema.json
@@ -309,6 +309,12 @@
 									"title": "Do not ask for confirmation",
 									"description": "Skip user confirmation to run the configured command",
 									"default": false
+								},
+								"allowFailures": {
+									"type": "boolean",
+									"title": "Allow command execution failures",
+									"description": "Ignore errors occurred during command execution and continue as normal",
+									"default": false
 								}
 							},
 							"required": [

--- a/src/Builder/Config/ValueObject/StepOptions.php
+++ b/src/Builder/Config/ValueObject/StepOptions.php
@@ -40,6 +40,7 @@ final class StepOptions
         private readonly ?string $artifactPath = null,
         private readonly ?string $command = null,
         private readonly bool $skipConfirmation = false,
+        private readonly bool $allowFailures = false,
     ) {}
 
     /**
@@ -68,5 +69,10 @@ final class StepOptions
     public function shouldSkipConfirmation(): bool
     {
         return $this->skipConfirmation;
+    }
+
+    public function shouldAllowFailures(): bool
+    {
+        return $this->allowFailures;
     }
 }

--- a/src/Builder/Config/ValueObject/StepOptions.php
+++ b/src/Builder/Config/ValueObject/StepOptions.php
@@ -40,7 +40,7 @@ final class StepOptions
         private readonly ?string $artifactPath = null,
         private readonly ?string $command = null,
         private readonly bool $skipConfirmation = false,
-        private readonly bool $allowFailures = false,
+        private readonly bool $allowFailure = false,
     ) {}
 
     /**
@@ -71,8 +71,8 @@ final class StepOptions
         return $this->skipConfirmation;
     }
 
-    public function shouldAllowFailures(): bool
+    public function shouldAllowFailure(): bool
     {
-        return $this->allowFailures;
+        return $this->allowFailure;
     }
 }

--- a/src/Builder/Generator/Step/RunCommandStep.php
+++ b/src/Builder/Generator/Step/RunCommandStep.php
@@ -79,7 +79,7 @@ final class RunCommandStep extends AbstractStep implements StepInterface, Stoppa
             $this->messenger->write($buffer, false);
         });
 
-        if (!$process->isSuccessful() && !$this->config->getOptions()->shouldAllowFailures()) {
+        if (!$process->isSuccessful() && !$this->config->getOptions()->shouldAllowFailure()) {
             return false;
         }
 

--- a/src/Builder/Generator/Step/RunCommandStep.php
+++ b/src/Builder/Generator/Step/RunCommandStep.php
@@ -79,7 +79,7 @@ final class RunCommandStep extends AbstractStep implements StepInterface, Stoppa
             $this->messenger->write($buffer, false);
         });
 
-        if (!$process->isSuccessful()) {
+        if (!$process->isSuccessful() && !$this->config->getOptions()->shouldAllowFailures()) {
             return false;
         }
 

--- a/tests/src/Builder/Generator/Step/RunCommandStepTest.php
+++ b/tests/src/Builder/Generator/Step/RunCommandStepTest.php
@@ -102,6 +102,31 @@ final class RunCommandStepTest extends Tests\ContainerAwareTestCase
     }
 
     #[Framework\Attributes\Test]
+    public function runExecutesCommandAndAllowsExecutionFailures(): void
+    {
+        $this->subject->setConfig(
+            new Src\Builder\Config\ValueObject\Step(
+                Src\Builder\Generator\Step\RunCommandStep::getType(),
+                new Src\Builder\Config\ValueObject\StepOptions(
+                    command: 'foo',
+                    allowFailures: true,
+                ),
+            ),
+        );
+
+        $workingDirectory = $this->result->getWrittenDirectory();
+
+        $fileSystem = new Filesystem\Filesystem();
+        if (!$fileSystem->exists($workingDirectory)) {
+            $fileSystem->mkdir($workingDirectory);
+        }
+
+        self::assertTrue($this->subject->run($this->result));
+        self::assertFalse($this->subject->isStopped());
+        self::assertStringContainsString('not found', self::$io->getOutput());
+    }
+
+    #[Framework\Attributes\Test]
     public function negatedQuestionForExecutionResultsInStoppedRun(): void
     {
         $this->subject->setConfig(

--- a/tests/src/Builder/Generator/Step/RunCommandStepTest.php
+++ b/tests/src/Builder/Generator/Step/RunCommandStepTest.php
@@ -109,7 +109,7 @@ final class RunCommandStepTest extends Tests\ContainerAwareTestCase
                 Src\Builder\Generator\Step\RunCommandStep::getType(),
                 new Src\Builder\Config\ValueObject\StepOptions(
                     command: 'foo',
-                    allowFailures: true,
+                    allowFailure: true,
                 ),
             ),
         );


### PR DESCRIPTION
This PR introduces a new configuration option `allowFailures` for the `runCommand` step. It allows to continue the normal project generation process even in cases of command execution failures.