### PR TITLE
[FEATURE] Support exclusion of template packages

### DIFF
--- a/docs/development/configuration.md
+++ b/docs/development/configuration.md
@@ -59,6 +59,32 @@ supported by your package:
 ```
 :::
 
+### Exclude packages from listing
+
+If a template package is published on a supported platform such as Packagist,
+it is always included in the list of available template packages when generating
+new projects.
+
+However, a single template package can also be explicitly excluded from that list.
+This may be useful if a package is not meant to be publicly used or if it's just
+published for demonstration or testing purposes.
+
+In such cases, template packages may provide the following configuration in
+their `composer.json` file:
+
+```{code-block} json
+:linenos:
+:caption: composer.json
+
+{
+    "extra": {
+        "cpsit/project-builder": {
+            "exclude-from-listing": true
+        }
+    }
+}
+```
+
 ## File structure
 
 Within the external Composer template package, the following file

--- a/src/Template/Provider/BaseProvider.php
+++ b/src/Template/Provider/BaseProvider.php
@@ -90,7 +90,7 @@ abstract class BaseProvider implements ProviderInterface
         foreach ($searchResult as ['name' => $packageName]) {
             $package = $repository->findPackage($packageName, $constraint);
 
-            if (null !== $package && self::PACKAGE_TYPE === $package->getType()) {
+            if (null !== $package && $this->isPackageSupported($package)) {
                 $templateSources[] = $this->createTemplateSource($package);
             }
         }
@@ -225,6 +225,20 @@ abstract class BaseProvider implements ProviderInterface
         $this->messenger->newLine();
 
         $this->requestPackageVersionConstraint($templateSource);
+    }
+
+    protected function isPackageSupported(Package\BasePackage $package): bool
+    {
+        if (self::PACKAGE_TYPE !== $package->getType()) {
+            return false;
+        }
+
+        $excludeFromListing = (bool) Helper\ArrayHelper::getValueByPath(
+            $package->getExtra(),
+            'cpsit/project-builder.exclude-from-listing',
+        );
+
+        return !$excludeFromListing;
     }
 
     protected function createTemplateSource(Package\BasePackage $package): Template\TemplateSource

--- a/tests/src/Template/Provider/BaseProviderTest.php
+++ b/tests/src/Template/Provider/BaseProviderTest.php
@@ -83,6 +83,32 @@ final class BaseProviderTest extends Tests\ContainerAwareTestCase
     }
 
     #[Framework\Attributes\Test]
+    public function listTemplateSourcesSkipsPackagesByConfiguration(): void
+    {
+        $package1 = self::createPackage('foo/baz-1');
+        $package1->setExtra([
+            'cpsit/project-builder' => [
+                'exclude-from-listing' => true,
+            ],
+        ]);
+        $package2 = self::createPackage('foo/baz-2');
+        $package3 = self::createPackage('foo/baz-3');
+
+        $this->subject->packages = [
+            $package1,
+            $package2,
+            $package3,
+        ];
+
+        $expected = [
+            new Src\Template\TemplateSource($this->subject, $package2),
+            new Src\Template\TemplateSource($this->subject, $package3),
+        ];
+
+        self::assertEquals($expected, $this->subject->listTemplateSources());
+    }
+
+    #[Framework\Attributes\Test]
     public function installTemplateSourceThrowsExceptionIfInstallationFails(): void
     {
         $package = self::createPackage('foo/baz');


### PR DESCRIPTION
This PR adds support for a new config option `extra.cpsit/project-builder.exclude-from-listing` within template packages. It allows to exclude packages from being listed in the template package selection.

Resolves: #472