### PR TITLE
[FEATURE] Add support for Composer 2.7

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         php-version: ["8.1", "8.2", "8.3"]
-        composer-version: ["2.1", "2.2", "2.3", "2.4", "2.5", "2.6"]
+        composer-version: ["2.1", "2.2", "2.3", "2.4", "2.5", "2.6", "2.7"]
         dependencies: ["highest", "lowest"]
     steps:
       - uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM composer/composer:2.6-bin AS composer
+FROM composer/composer:2.7-bin AS composer
 LABEL maintainer="Elias Häußler <e.haeussler@familie-redlich.de>"
 
 FROM php:8.3-alpine


### PR DESCRIPTION
Composer 2.7 was released and this PR adds support for the new minor version. In addition, the Docker image was changed to use Composer 2.7 instead of 2.6.