### PR TITLE
[BUGFIX] Ignore "exclude-from-listing" config in VCS provider

### DIFF
--- a/src/Template/Provider/VcsProvider.php
+++ b/src/Template/Provider/VcsProvider.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace CPSIT\ProjectBuilder\Template\Provider;
 
 use Composer\Factory;
+use Composer\Package;
 use CPSIT\ProjectBuilder\Exception;
 use CPSIT\ProjectBuilder\IO;
 use CPSIT\ProjectBuilder\Template;
@@ -138,6 +139,11 @@ final class VcsProvider extends BaseProvider implements CustomProviderInterface
             $this->messenger->writeWithEmoji(IO\Emoji::WhiteHeavyCheckMark->value, 'Package added.');
             $this->messenger->newLine();
         }
+    }
+
+    protected function isPackageSupported(Package\BasePackage $package): bool
+    {
+        return self::PACKAGE_TYPE === $package->getType();
     }
 
     protected function createComposerJson(array $templateSources, array $repositories = []): string


### PR DESCRIPTION
When explicitly requiring a template package using the VCS provider, the underlying repository should always be listed, even if it's configured to be excluded from listing using the configuration option introduced with #473.