### PR TITLE
[TASK] Disable Composer cache while searching for template packages

### DIFF
--- a/src/Template/Provider/BaseProvider.php
+++ b/src/Template/Provider/BaseProvider.php
@@ -28,6 +28,7 @@ use Composer\IO as ComposerIO;
 use Composer\Package;
 use Composer\Repository;
 use Composer\Semver;
+use Composer\Util;
 use CPSIT\ProjectBuilder\Exception;
 use CPSIT\ProjectBuilder\Helper;
 use CPSIT\ProjectBuilder\IO;
@@ -290,6 +291,7 @@ abstract class BaseProvider implements ProviderInterface
         $config = Factory::createConfig($this->io);
         $config->merge([
             'config' => [
+                'cache-dir' => Util\Platform::isWindows() ? 'nul' : '/dev/null',
                 'secure-http' => !$this->acceptInsecureConnections,
             ],
         ]);

--- a/tests/src/Template/Provider/BaseProviderTest.php
+++ b/tests/src/Template/Provider/BaseProviderTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace CPSIT\ProjectBuilder\Tests\Template\Provider;
 
+use Composer\Cache;
 use Composer\Package;
 use Composer\Repository;
 use Composer\Semver\Constraint;
@@ -32,6 +33,7 @@ use CPSIT\ProjectBuilder\Tests;
 use donatj\MockWebServer;
 use Generator;
 use PHPUnit\Framework;
+use ReflectionObject;
 use Symfony\Component\Filesystem;
 
 use function array_map;
@@ -236,6 +238,21 @@ final class BaseProviderTest extends Tests\ContainerAwareTestCase
 
         self::assertInstanceOf(Repository\ComposerRepository::class, $actual);
         self::assertSame($this->subject->getUrl(), $actual->getRepoConfig()['url']);
+    }
+
+    #[Framework\Attributes\Test]
+    public function createRepositoryReturnsComposerRepositoryWithDisabledCache(): void
+    {
+        $actual = $this->subject->testCreateRepository();
+
+        self::assertInstanceOf(Repository\ComposerRepository::class, $actual);
+
+        $repositoryReflection = new ReflectionObject($actual);
+        $cacheReflection = $repositoryReflection->getProperty('cache');
+        $cache = $cacheReflection->getValue($actual);
+
+        self::assertInstanceOf(Cache::class, $cache);
+        self::assertFalse(Cache::isUsable($cache->getRoot()));
     }
 
     /**

--- a/tests/src/Template/Provider/VcsProviderTest.php
+++ b/tests/src/Template/Provider/VcsProviderTest.php
@@ -31,6 +31,7 @@ use PHPUnit\Framework;
 use ReflectionObject;
 use ReflectionProperty;
 use SebastianFeldmann\Cli;
+use Symfony\Component\Console;
 use Symfony\Component\Filesystem;
 
 use function chdir;
@@ -95,6 +96,13 @@ final class VcsProviderTest extends Tests\ContainerAwareTestCase
     {
         $repoA = $this->initializeGitRepository('test/repo-a', ['test/repo-b' => '*']);
         $io = $this->fetchIOViaReflection();
+
+        // Enforce output during package lookup
+        $this->setPropertyValueOnObject(
+            $io,
+            'output',
+            new Console\Output\BufferedOutput(Console\Output\OutputInterface::VERBOSITY_VERY_VERBOSE),
+        );
 
         self::$io->setUserInputs([$repoA]);
 


### PR DESCRIPTION
This PR defines the `cache-dir` config option to disable Composer cache while searching and listing template packages. This avoids outdated package information. All other areas are not touched and still rely on Composer's internal caching behavior.