### PR TITLE
[BUGFIX] Disable template source cache for simulations only

### DIFF
--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -49,6 +49,7 @@ final class Bootstrap
         Script\Event $event,
         ?string $targetDirectory = null,
         bool $exitOnFailure = true,
+        bool $disableTemplateSourceCache = false,
     ): int {
         // Early return if current environment is unsupported
         if (self::runsOnAnUnsupportedEnvironment()) {
@@ -59,7 +60,7 @@ final class Bootstrap
         $targetDirectory ??= Helper\FilesystemHelper::getProjectRootPath();
 
         // Create new project
-        $exitCode = self::createApplication($messenger, $targetDirectory)->run();
+        $exitCode = self::createApplication($messenger, $targetDirectory)->run($disableTemplateSourceCache);
 
         $event->stopPropagation();
 
@@ -87,7 +88,7 @@ final class Bootstrap
         $targetDirectory = $simulation->prepare();
 
         $exitCode = $simulation->run(
-            static fn (): int => self::createProject($event, $targetDirectory, false),
+            static fn (): int => self::createProject($event, $targetDirectory, false, true),
         );
 
         exit($exitCode);

--- a/src/Template/Provider/VcsProvider.php
+++ b/src/Template/Provider/VcsProvider.php
@@ -25,6 +25,7 @@ namespace CPSIT\ProjectBuilder\Template\Provider;
 
 use Composer\Factory;
 use Composer\Package;
+use Composer\Repository;
 use CPSIT\ProjectBuilder\Exception;
 use CPSIT\ProjectBuilder\IO;
 use CPSIT\ProjectBuilder\Template;
@@ -151,6 +152,21 @@ final class VcsProvider extends BaseProvider implements CustomProviderInterface
         $repositories = [...$repositories, ...$this->repositories];
 
         return parent::createComposerJson($templateSources, $repositories);
+    }
+
+    protected function createRepository(): Repository\RepositoryInterface
+    {
+        $isCacheDisabled = $this->disableCache;
+
+        // Explicitly enable package cache as Composer requires caching to be enabled for Git operations
+        $this->disableCache = false;
+
+        try {
+            return parent::createRepository();
+        } finally {
+            // Restore original setting
+            $this->disableCache = $isCacheDisabled;
+        }
     }
 
     protected function getRepositoryType(): string

--- a/tests/src/Template/Provider/BaseProviderTest.php
+++ b/tests/src/Template/Provider/BaseProviderTest.php
@@ -243,6 +243,8 @@ final class BaseProviderTest extends Tests\ContainerAwareTestCase
     #[Framework\Attributes\Test]
     public function createRepositoryReturnsComposerRepositoryWithDisabledCache(): void
     {
+        $this->subject->disableCache();
+
         $actual = $this->subject->testCreateRepository();
 
         self::assertInstanceOf(Repository\ComposerRepository::class, $actual);


### PR DESCRIPTION
This PR fixes a regression introduced with #478. The disabled package cache is not supported by all underlying Composer operations. Therefore, this PR changes the configuration of package caches and only disables them for simulation during development. In addition, the `VcsProvider` is configured to always explicitly *enable* package cache since Git operations require caches to be active.