### PR TITLE
[BUGFIX] Fix outdated link to documentation

### DIFF
--- a/src/IO/Messenger.php
+++ b/src/IO/Messenger.php
@@ -191,7 +191,7 @@ final class Messenger
             'You can go one step back and select another template provider.',
             sprintf(
                 'For more information, take a look at the <href=%s>documentation</>.',
-                'https://github.com/CPS-IT/project-builder/blob/main/docs/configuration.md',
+                'https://project-builder.cps-it.de/development/configuration.html',
             ),
             '',
         ]);


### PR DESCRIPTION
When documentation was restructured and deployed to https://project-builder.cps-it.de/, a referencing link was not exchanged. This is now fixed.