### PR TITLE
[FEATURE] Introduce event for collected build instructions

### DIFF
--- a/docs/development/architecture/events.md
+++ b/docs/development/architecture/events.md
@@ -19,6 +19,10 @@ The following events are currently dispatched:
 * [**`ProjectBuildFinishedEvent`**](https://github.com/CPS-IT/project-builder/blob/main/src/Event/ProjectBuildFinishedEvent.php)
   is dispatched once the whole project build process is finished. It provides
   the build result containing all processed build steps and the final result.
+* [**`BuildInstructionCollectedEvent`**](https://github.com/CPS-IT/project-builder/blob/main/src/Event/BuildInstructionCollectedEvent.php)
+  is dispatched when a collected build instruction is about to be applied to
+  the build result. It allows to modify the instructed value by calling
+  `setValue()`.
 * [**`BuildStepProcessedEvent`**](https://github.com/CPS-IT/project-builder/blob/main/src/Event/BuildStepProcessedEvent.php) is
   dispatched once a configured step is processed, either successfully or failing.
   The event provides information about the processed step and its result and

--- a/src/Event/BuildInstructionCollectedEvent.php
+++ b/src/Event/BuildInstructionCollectedEvent.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/project-builder".
+ *
+ * Copyright (C) 2024 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\ProjectBuilder\Event;
+
+use CPSIT\ProjectBuilder\Builder;
+
+/**
+ * BuildInstructionCollectedEvent.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+final class BuildInstructionCollectedEvent
+{
+    public function __construct(
+        private readonly Builder\Config\ValueObject\Property|Builder\Config\ValueObject\SubProperty $property,
+        private readonly string $path,
+        private mixed $value,
+        private readonly Builder\BuildResult $buildResult,
+    ) {}
+
+    public function getProperty(): Builder\Config\ValueObject\Property|Builder\Config\ValueObject\SubProperty
+    {
+        return $this->property;
+    }
+
+    /**
+     * @phpstan-assert-if-true Builder\Config\ValueObject\Property $this->getProperty()
+     */
+    public function isProperty(): bool
+    {
+        return $this->property instanceof Builder\Config\ValueObject\Property;
+    }
+
+    /**
+     * @phpstan-assert-if-true Builder\Config\ValueObject\SubProperty $this->getProperty()
+     */
+    public function isSubProperty(): bool
+    {
+        return $this->property instanceof Builder\Config\ValueObject\SubProperty;
+    }
+
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+
+    public function getValue(): mixed
+    {
+        return $this->value;
+    }
+
+    public function setValue(mixed $value): self
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    public function getBuildResult(): Builder\BuildResult
+    {
+        return $this->buildResult;
+    }
+}

--- a/tests/config/services.yaml
+++ b/tests/config/services.yaml
@@ -13,6 +13,9 @@ services:
       - name: event.listener
         method: onEventDispatch
         event: CPSIT\ProjectBuilder\Event\BuildStepRevertedEvent
+      - name: event.listener
+        method: onEventDispatch
+        event: CPSIT\ProjectBuilder\Event\BuildInstructionCollectedEvent
 
   CPSIT\ProjectBuilder\Tests\Fixtures\DummyTemplateRenderingEventListener:
     tags: ['event.listener']

--- a/tests/src/Builder/Generator/GeneratorTest.php
+++ b/tests/src/Builder/Generator/GeneratorTest.php
@@ -80,14 +80,16 @@ final class GeneratorTest extends Tests\ContainerAwareTestCase
         self::assertFileExists($this->targetDirectory.'/dummy.yaml');
         self::assertStringEqualsFile($this->targetDirectory.'/dummy.yaml', 'name: "foo"'.PHP_EOL);
 
-        self::assertCount(9, $this->eventListener->dispatchedEvents);
+        self::assertCount(11, $this->eventListener->dispatchedEvents);
         self::assertInstanceOf(Src\Event\ProjectBuildStartedEvent::class, $this->eventListener->dispatchedEvents[0]);
+        self::assertInstanceOf(Src\Event\BuildInstructionCollectedEvent::class, $this->eventListener->dispatchedEvents[1]);
+        self::assertInstanceOf(Src\Event\BuildInstructionCollectedEvent::class, $this->eventListener->dispatchedEvents[2]);
 
-        for ($i = 1; $i <= 7; ++$i) {
+        for ($i = 3; $i <= 9; ++$i) {
             self::assertInstanceOf(Src\Event\BuildStepProcessedEvent::class, $this->eventListener->dispatchedEvents[$i]);
         }
 
-        self::assertInstanceOf(Src\Event\ProjectBuildFinishedEvent::class, $this->eventListener->dispatchedEvents[8]);
+        self::assertInstanceOf(Src\Event\ProjectBuildFinishedEvent::class, $this->eventListener->dispatchedEvents[10]);
     }
 
     #[Framework\Attributes\Test]
@@ -112,17 +114,20 @@ final class GeneratorTest extends Tests\ContainerAwareTestCase
         self::assertFileExists($this->targetDirectory.'/dummy.yaml');
         self::assertStringEqualsFile($this->targetDirectory.'/dummy.yaml', 'name: "foo"'.PHP_EOL);
 
-        self::assertCount(12, $this->eventListener->dispatchedEvents);
+        self::assertCount(15, $this->eventListener->dispatchedEvents);
         self::assertInstanceOf(Src\Event\ProjectBuildStartedEvent::class, $this->eventListener->dispatchedEvents[0]);
-        self::assertInstanceOf(Src\Event\BuildStepProcessedEvent::class, $this->eventListener->dispatchedEvents[1]);
-        self::assertInstanceOf(Src\Event\BuildStepRevertedEvent::class, $this->eventListener->dispatchedEvents[2]);
-        self::assertInstanceOf(Src\Event\ProjectBuildStartedEvent::class, $this->eventListener->dispatchedEvents[3]);
+        self::assertInstanceOf(Src\Event\BuildInstructionCollectedEvent::class, $this->eventListener->dispatchedEvents[1]);
+        self::assertInstanceOf(Src\Event\BuildStepProcessedEvent::class, $this->eventListener->dispatchedEvents[2]);
+        self::assertInstanceOf(Src\Event\BuildStepRevertedEvent::class, $this->eventListener->dispatchedEvents[3]);
+        self::assertInstanceOf(Src\Event\ProjectBuildStartedEvent::class, $this->eventListener->dispatchedEvents[4]);
+        self::assertInstanceOf(Src\Event\BuildInstructionCollectedEvent::class, $this->eventListener->dispatchedEvents[5]);
+        self::assertInstanceOf(Src\Event\BuildInstructionCollectedEvent::class, $this->eventListener->dispatchedEvents[6]);
 
-        for ($i = 4; $i <= 10; ++$i) {
+        for ($i = 7; $i <= 13; ++$i) {
             self::assertInstanceOf(Src\Event\BuildStepProcessedEvent::class, $this->eventListener->dispatchedEvents[$i]);
         }
 
-        self::assertInstanceOf(Src\Event\ProjectBuildFinishedEvent::class, $this->eventListener->dispatchedEvents[11]);
+        self::assertInstanceOf(Src\Event\ProjectBuildFinishedEvent::class, $this->eventListener->dispatchedEvents[14]);
     }
 
     #[Framework\Attributes\Test]
@@ -153,10 +158,11 @@ final class GeneratorTest extends Tests\ContainerAwareTestCase
             $this->subject->getRevertedSteps()[0],
         );
 
-        self::assertCount(3, $this->eventListener->dispatchedEvents);
+        self::assertCount(4, $this->eventListener->dispatchedEvents);
         self::assertInstanceOf(Src\Event\ProjectBuildStartedEvent::class, $this->eventListener->dispatchedEvents[0]);
-        self::assertInstanceOf(Src\Event\BuildStepProcessedEvent::class, $this->eventListener->dispatchedEvents[1]);
-        self::assertInstanceOf(Src\Event\BuildStepRevertedEvent::class, $this->eventListener->dispatchedEvents[2]);
+        self::assertInstanceOf(Src\Event\BuildInstructionCollectedEvent::class, $this->eventListener->dispatchedEvents[1]);
+        self::assertInstanceOf(Src\Event\BuildStepProcessedEvent::class, $this->eventListener->dispatchedEvents[2]);
+        self::assertInstanceOf(Src\Event\BuildStepRevertedEvent::class, $this->eventListener->dispatchedEvents[3]);
     }
 
     #[Framework\Attributes\Test]

--- a/tests/src/Event/BuildInstructionCollectedEventTest.php
+++ b/tests/src/Event/BuildInstructionCollectedEventTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/project-builder".
+ *
+ * Copyright (C) 2024 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\ProjectBuilder\Tests\Event;
+
+use CPSIT\ProjectBuilder as Src;
+use CPSIT\ProjectBuilder\Tests;
+use PHPUnit\Framework;
+
+/**
+ * BuildInstructionCollectedEventTest.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+final class BuildInstructionCollectedEventTest extends Tests\ContainerAwareTestCase
+{
+    private Src\Builder\Config\ValueObject\SubProperty $subProperty;
+    private Src\Builder\Config\ValueObject\Property $property;
+    private Src\Builder\BuildResult $buildResult;
+    private Src\Event\BuildInstructionCollectedEvent $subject;
+
+    protected function setUp(): void
+    {
+        $this->subProperty = new Src\Builder\Config\ValueObject\SubProperty(
+            'bar',
+            'Bar',
+            'staticValue',
+            null,
+            'false',
+        );
+        $this->property = new Src\Builder\Config\ValueObject\Property(
+            'foo',
+            'Foo',
+            null,
+            null,
+            'FOO',
+            [
+                $this->subProperty,
+            ],
+        );
+        $this->buildResult = new Src\Builder\BuildResult(
+            new Src\Builder\BuildInstructions(self::$config, 'foo'),
+        );
+        $this->subject = new Src\Event\BuildInstructionCollectedEvent(
+            $this->property,
+            'foo',
+            'FOO',
+            $this->buildResult,
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function getPropertyReturnsProperty(): void
+    {
+        self::assertSame(
+            $this->property,
+            $this->subject->getProperty(),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function isPropertyReturnsTrueIfGivenPropertyIsAProperty(): void
+    {
+        self::assertTrue($this->subject->isProperty());
+        self::assertFalse($this->subject->isSubProperty());
+    }
+
+    #[Framework\Attributes\Test]
+    public function isSubPropertyReturnsTrueIfGivenPropertyIsASubProperty(): void
+    {
+        $subject = new Src\Event\BuildInstructionCollectedEvent(
+            $this->subProperty,
+            'bar',
+            null,
+            $this->buildResult,
+        );
+
+        self::assertTrue($subject->isSubProperty());
+        self::assertFalse($subject->isProperty());
+    }
+
+    #[Framework\Attributes\Test]
+    public function getPathReturnsPath(): void
+    {
+        self::assertSame(
+            'foo',
+            $this->subject->getPath(),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function getValueReturnsValue(): void
+    {
+        self::assertSame(
+            'FOO',
+            $this->subject->getValue(),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function setValueAppliesNewValue(): void
+    {
+        $this->subject->setValue('bar');
+
+        self::assertSame(
+            'bar',
+            $this->subject->getValue(),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function getBuildResultReturnsBuildResult(): void
+    {
+        self::assertSame(
+            $this->buildResult,
+            $this->subject->getBuildResult(),
+        );
+    }
+}


### PR DESCRIPTION
This PR introduces a new `BuildInstructionCollectedEvent`. It is dispatched in `CollectBuildInstructionsStep` each time a build instruction is about to be applied to the underlying `BuildResult`. The event can be used to modify the collected value for the configured property or sub-property.