### PR TITLE
[TASK] Run JSON schema validation on all available JSON schemas

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -136,6 +136,9 @@
 		"test:docker": "tests/docker/docker-build.sh",
 		"test:unit": "@test:unit:coverage --no-coverage",
 		"test:unit:coverage": "phpunit -c phpunit.xml",
-		"validate-schema": "docker run --rm -v \"$(pwd)\":/code swaggest/json-cli json-cli validate-schema resources/config.schema.json"
+		"validate-schema": [
+			"docker run --rm -v \"$(pwd)\":/code swaggest/json-cli json-cli validate-schema resources/build-artifact.schema.json",
+			"docker run --rm -v \"$(pwd)\":/code swaggest/json-cli json-cli validate-schema resources/config.schema.json"
+		]
 	}
 }


### PR DESCRIPTION
This PR extends the `validate-schema` Composer script to validate all available JSON schema files.