### PR TITLE
[TASK] Use errors identifiers in `@phpstan-ignore-*` annotations

### DIFF
--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -107,7 +107,7 @@ final class Bootstrap
 
     private static function runsOnAnUnsupportedEnvironment(): bool
     {
-        /* @phpstan-ignore-next-line */
+        /* @phpstan-ignore-next-line function.alreadyNarrowedType */
         return !method_exists(InstalledVersions::class, 'getInstallPath');
     }
 }

--- a/src/IO/Validator/AbstractValidator.php
+++ b/src/IO/Validator/AbstractValidator.php
@@ -59,7 +59,7 @@ abstract class AbstractValidator implements ValidatorInterface
             throw Exception\MisconfiguredValidatorException::forUnexpectedOptions($this, array_keys($invalidOptions));
         }
 
-        /* @phpstan-ignore-next-line */
+        /* @phpstan-ignore-next-line assign.propertyType */
         $this->options = [...static::$defaultOptions, ...$options];
     }
 }

--- a/src/IO/Validator/NotEmptyValidator.php
+++ b/src/IO/Validator/NotEmptyValidator.php
@@ -66,7 +66,7 @@ final class NotEmptyValidator extends AbstractValidator
 
     private function isStrictCheckEnabled(): bool
     {
-        /* @phpstan-ignore-next-line */
+        /* @phpstan-ignore-next-line cast.useless */
         return (bool) $this->options['strict'];
     }
 }

--- a/tests/src/Helper/StringHelperTest.php
+++ b/tests/src/Helper/StringHelperTest.php
@@ -51,7 +51,7 @@ final class StringHelperTest extends Framework\TestCase
     {
         $this->expectException(UnhandledMatchError::class);
 
-        /* @phpstan-ignore-next-line */
+        /* @phpstan-ignore-next-line argument.type */
         Src\Helper\StringHelper::convertCase('foo', 'bar');
     }
 

--- a/tests/src/IO/Validator/CallbackValidatorTest.php
+++ b/tests/src/IO/Validator/CallbackValidatorTest.php
@@ -59,7 +59,7 @@ final class CallbackValidatorTest extends Framework\TestCase
             Src\Exception\MisconfiguredValidatorException::forUnexpectedOption($this->subject, 'callback'),
         );
 
-        /* @phpstan-ignore-next-line */
+        /* @phpstan-ignore-next-line argument.type */
         new Src\IO\Validator\CallbackValidator(['callback' => 'foo']);
     }
 

--- a/tests/src/Naming/NameVariantBuilderTest.php
+++ b/tests/src/Naming/NameVariantBuilderTest.php
@@ -55,7 +55,7 @@ final class NameVariantBuilderTest extends Tests\ContainerAwareTestCase
     {
         $this->expectException(UnhandledMatchError::class);
 
-        /* @phpstan-ignore-next-line */
+        /* @phpstan-ignore-next-line argument.type */
         $this->subject->createVariant('foo');
     }
 

--- a/tests/src/Twig/Func/NameVariantFunctionTest.php
+++ b/tests/src/Twig/Func/NameVariantFunctionTest.php
@@ -59,7 +59,7 @@ final class NameVariantFunctionTest extends Tests\ContainerAwareTestCase
         $this->expectException(Assert\InvalidArgumentException::class);
         $this->expectExceptionMessage('Expected an instance of '.Src\Builder\BuildInstructions::class.'. Got: NULL');
 
-        /* @phpstan-ignore-next-line */
+        /* @phpstan-ignore-next-line argument.type */
         ($this->subject)([], 'foo');
     }
 


### PR DESCRIPTION
This PR adds error identifiers to all `@phpstan-ignore-*` annotations to avoid unreported PHPStan errors.