### PR TITLE
[BUGFIX] Properly isolate instances in Unit tests

### DIFF
--- a/tests/src/Builder/BuildInstructionsTest.php
+++ b/tests/src/Builder/BuildInstructionsTest.php
@@ -42,8 +42,10 @@ final class BuildInstructionsTest extends Tests\ContainerAwareTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new Src\Builder\BuildInstructions(
-            self::$container->get('app.config'),
+            $this->container->get('app.config'),
             'foo',
         );
     }
@@ -51,7 +53,7 @@ final class BuildInstructionsTest extends Tests\ContainerAwareTestCase
     #[Framework\Attributes\Test]
     public function getConfigReturnsConfig(): void
     {
-        self::assertSame(self::$container->get('app.config'), $this->subject->getConfig());
+        self::assertSame($this->container->get('app.config'), $this->subject->getConfig());
     }
 
     #[Framework\Attributes\Test]

--- a/tests/src/Builder/BuildResultTest.php
+++ b/tests/src/Builder/BuildResultTest.php
@@ -45,8 +45,10 @@ final class BuildResultTest extends Tests\ContainerAwareTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->instructions = new Src\Builder\BuildInstructions(
-            self::$container->get('app.config'),
+            $this->container->get('app.config'),
             'foo',
         );
         $this->subject = new Src\Builder\BuildResult($this->instructions);
@@ -104,7 +106,7 @@ final class BuildResultTest extends Tests\ContainerAwareTestCase
 
         self::assertFalse($this->subject->isStepApplied('foo'));
         self::assertFalse($this->subject->isStepApplied(
-            self::$container->get(Src\Builder\Generator\Step\InstallComposerDependenciesStep::class),
+            $this->container->get(Src\Builder\Generator\Step\InstallComposerDependenciesStep::class),
         ));
     }
 

--- a/tests/src/Builder/Generator/GeneratorTest.php
+++ b/tests/src/Builder/Generator/GeneratorTest.php
@@ -46,15 +46,17 @@ final class GeneratorTest extends Tests\ContainerAwareTestCase
 
     protected function setUp(): void
     {
-        $this->subject = self::$container->get(Src\Builder\Generator\Generator::class);
-        $this->eventListener = self::$container->get(Tests\Fixtures\DummyEventListener::class);
+        parent::setUp();
+
+        $this->subject = $this->container->get(Src\Builder\Generator\Generator::class);
+        $this->eventListener = $this->container->get(Tests\Fixtures\DummyEventListener::class);
         $this->targetDirectory = Src\Helper\FilesystemHelper::getNewTemporaryDirectory();
     }
 
     #[Framework\Attributes\Test]
     public function runRunsThroughAllConfiguredSteps(): void
     {
-        self::$io->setUserInputs(['foo']);
+        $this->io->setUserInputs(['foo']);
 
         self::assertCount(0, $this->eventListener->dispatchedEvents);
 
@@ -68,7 +70,7 @@ final class GeneratorTest extends Tests\ContainerAwareTestCase
         self::assertTrue($actual->isStepApplied('runCommand'));
         self::assertTrue($actual->isMirrored());
 
-        $output = self::$io->getOutput();
+        $output = $this->io->getOutput();
 
         self::assertStringContainsString('Running step #1 "collectBuildInstructions"...', $output);
         self::assertStringContainsString('Running step #2 "processSourceFiles"...', $output);
@@ -95,7 +97,7 @@ final class GeneratorTest extends Tests\ContainerAwareTestCase
     #[Framework\Attributes\Test]
     public function runRestartsProjectGenerationOnStepFailure(): void
     {
-        self::$io->setUserInputs(['', '', '', 'yes', 'foo']);
+        $this->io->setUserInputs(['', '', '', 'yes', 'foo']);
 
         self::assertCount(0, $this->eventListener->dispatchedEvents);
 
@@ -108,7 +110,7 @@ final class GeneratorTest extends Tests\ContainerAwareTestCase
         self::assertTrue($actual->isStepApplied('mirrorProcessedFiles'));
         self::assertTrue($actual->isMirrored());
 
-        $output = self::$io->getOutput();
+        $output = $this->io->getOutput();
 
         self::assertStringContainsString('If you want, you can restart project generation now.', $output);
         self::assertFileExists($this->targetDirectory.'/dummy.yaml');
@@ -135,7 +137,7 @@ final class GeneratorTest extends Tests\ContainerAwareTestCase
     {
         $exception = null;
 
-        self::$io->setUserInputs(['', '', '', 'no']);
+        $this->io->setUserInputs(['', '', '', 'no']);
 
         try {
             $this->subject->run($this->targetDirectory);
@@ -144,7 +146,7 @@ final class GeneratorTest extends Tests\ContainerAwareTestCase
 
         self::assertStringContainsString(
             'Project generation failed. All processed steps will be reverted',
-            self::$io->getOutput(),
+            $this->io->getOutput(),
         );
 
         self::assertInstanceOf(Src\Exception\StepFailureException::class, $exception);
@@ -168,7 +170,7 @@ final class GeneratorTest extends Tests\ContainerAwareTestCase
     #[Framework\Attributes\Test]
     public function runRevertsAppliedStepsAndExistsIfStoppableStepFailed(): void
     {
-        self::$io->setUserInputs(['foo', 'no']);
+        $this->io->setUserInputs(['foo', 'no']);
 
         $actual = $this->subject->run($this->targetDirectory);
 
@@ -179,15 +181,15 @@ final class GeneratorTest extends Tests\ContainerAwareTestCase
     #[Framework\Attributes\Test]
     public function runDisplaysExceptionMessageOnVerboseOutput(): void
     {
-        self::$io->setVerbosity(Console\Output\OutputInterface::VERBOSITY_VERBOSE);
-        self::$io->setUserInputs(['', '', '', 'no']);
+        $this->io->setVerbosity(Console\Output\OutputInterface::VERBOSITY_VERBOSE);
+        $this->io->setUserInputs(['', '', '', 'no']);
 
         try {
             $this->subject->run($this->targetDirectory);
         } catch (Src\Exception\StepFailureException) {
         }
 
-        $output = self::$io->getOutput();
+        $output = $this->io->getOutput();
 
         self::assertStringContainsString(
             'Exception: The given input must not be empty.',
@@ -199,8 +201,8 @@ final class GeneratorTest extends Tests\ContainerAwareTestCase
     #[Framework\Attributes\Test]
     public function runDisplaysExceptionTraceOnVeryVerboseOutput(): void
     {
-        self::$io->setVerbosity(Console\Output\OutputInterface::VERBOSITY_VERY_VERBOSE);
-        self::$io->setUserInputs(['', '', '', 'no']);
+        $this->io->setVerbosity(Console\Output\OutputInterface::VERBOSITY_VERY_VERBOSE);
+        $this->io->setUserInputs(['', '', '', 'no']);
 
         try {
             $this->subject->run($this->targetDirectory);
@@ -209,14 +211,14 @@ final class GeneratorTest extends Tests\ContainerAwareTestCase
 
         self::assertStringContainsString(
             'Exception: The given input must not be empty.'.PHP_EOL.'#0',
-            self::$io->getOutput(),
+            $this->io->getOutput(),
         );
     }
 
     #[Framework\Attributes\Test]
     public function dumpArtifactDumpsBuildArtifact(): void
     {
-        self::$io->setUserInputs(['foo']);
+        $this->io->setUserInputs(['foo']);
 
         $result = $this->subject->run($this->targetDirectory);
 
@@ -228,7 +230,7 @@ final class GeneratorTest extends Tests\ContainerAwareTestCase
     #[Framework\Attributes\Test]
     public function cleanUpCleansUpRemainingFilesInTargetDirectory(): void
     {
-        self::$io->setUserInputs(['foo']);
+        $this->io->setUserInputs(['foo']);
 
         $result = $this->subject->run($this->targetDirectory);
 
@@ -237,7 +239,7 @@ final class GeneratorTest extends Tests\ContainerAwareTestCase
         self::assertTrue($result->isStepApplied('cleanUp'));
     }
 
-    protected static function createConfig(): Src\Builder\Config\Config
+    protected function createConfig(): Src\Builder\Config\Config
     {
         $configReader = Src\Builder\Config\ConfigFactory::create();
 
@@ -257,8 +259,6 @@ final class GeneratorTest extends Tests\ContainerAwareTestCase
 
     protected function tearDown(): void
     {
-        parent::tearDown();
-
         $this->eventListener->dispatchedEvents = [];
 
         $filesystem = new Filesystem\Filesystem();

--- a/tests/src/Builder/Generator/Step/CleanUpStepTest.php
+++ b/tests/src/Builder/Generator/Step/CleanUpStepTest.php
@@ -43,11 +43,13 @@ final class CleanUpStepTest extends Tests\ContainerAwareTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->filesystem = new Filesystem\Filesystem();
         $this->subject = new Src\Builder\Generator\Step\CleanUpStep($this->filesystem);
         $this->result = new Src\Builder\BuildResult(
             new Src\Builder\BuildInstructions(
-                self::$config,
+                $this->config,
                 Src\Helper\FilesystemHelper::getNewTemporaryDirectory(),
             ),
         );

--- a/tests/src/Builder/Generator/Step/CollectBuildInstructionsStepTest.php
+++ b/tests/src/Builder/Generator/Step/CollectBuildInstructionsStepTest.php
@@ -40,8 +40,10 @@ final class CollectBuildInstructionsStepTest extends Tests\ContainerAwareTestCas
 
     protected function setUp(): void
     {
-        $this->subject = self::$container->get(Src\Builder\Generator\Step\CollectBuildInstructionsStep::class);
-        $this->eventListener = self::$container->get(Tests\Fixtures\DummyEventListener::class);
+        parent::setUp();
+
+        $this->subject = $this->container->get(Src\Builder\Generator\Step\CollectBuildInstructionsStep::class);
+        $this->eventListener = $this->container->get(Tests\Fixtures\DummyEventListener::class);
     }
 
     #[Framework\Attributes\Test]
@@ -183,8 +185,6 @@ final class CollectBuildInstructionsStepTest extends Tests\ContainerAwareTestCas
 
     protected function tearDown(): void
     {
-        parent::tearDown();
-
         $this->eventListener->dispatchedEvents = [];
     }
 }

--- a/tests/src/Builder/Generator/Step/DumpBuildArtifactStepTest.php
+++ b/tests/src/Builder/Generator/Step/DumpBuildArtifactStepTest.php
@@ -46,13 +46,15 @@ final class DumpBuildArtifactStepTest extends Tests\ContainerAwareTestCase
 
     protected function setUp(): void
     {
-        $this->filesystem = self::$container->get(Filesystem\Filesystem::class);
+        parent::setUp();
+
+        $this->filesystem = $this->container->get(Filesystem\Filesystem::class);
         $this->subject = new Src\Builder\Generator\Step\DumpBuildArtifactStep(
             $this->filesystem,
-            self::$container->get(Src\Builder\Writer\JsonFileWriter::class),
+            $this->container->get(Src\Builder\Writer\JsonFileWriter::class),
         );
         $this->buildResult = new Src\Builder\BuildResult(
-            new Src\Builder\BuildInstructions(self::$config, 'foo'),
+            new Src\Builder\BuildInstructions($this->config, 'foo'),
         );
         $this->buildArtifact = new Src\Builder\Artifact\BuildArtifact(
             'foo.json',
@@ -125,8 +127,6 @@ final class DumpBuildArtifactStepTest extends Tests\ContainerAwareTestCase
 
     protected function tearDown(): void
     {
-        parent::tearDown();
-
         $this->filesystem->remove($this->buildArtifact->getFile()->getPathname());
     }
 }

--- a/tests/src/Builder/Generator/Step/GenerateBuildArtifactStepTest.php
+++ b/tests/src/Builder/Generator/Step/GenerateBuildArtifactStepTest.php
@@ -44,10 +44,12 @@ final class GenerateBuildArtifactStepTest extends Tests\ContainerAwareTestCase
 
     protected function setUp(): void
     {
-        $this->subject = self::$container->get(Src\Builder\Generator\Step\GenerateBuildArtifactStep::class);
-        $this->filesystem = self::$container->get(Filesystem\Filesystem::class);
+        parent::setUp();
+
+        $this->subject = $this->container->get(Src\Builder\Generator\Step\GenerateBuildArtifactStep::class);
+        $this->filesystem = $this->container->get(Filesystem\Filesystem::class);
         $this->buildResult = new Src\Builder\BuildResult(
-            new Src\Builder\BuildInstructions(self::$config, 'foo'),
+            new Src\Builder\BuildInstructions($this->config, 'foo'),
         );
         $this->artifactPath = Filesystem\Path::join(
             $this->buildResult->getWrittenDirectory(),
@@ -59,7 +61,7 @@ final class GenerateBuildArtifactStepTest extends Tests\ContainerAwareTestCase
     #[Framework\Attributes\DataProvider('runAsksForConfirmationIfBuildArtifactPathAlreadyExistsDataProvider')]
     public function runAsksForConfirmationIfBuildArtifactPathAlreadyExists(bool $continue, bool $expected): void
     {
-        self::$io->setUserInputs([$continue ? 'yes' : 'no']);
+        $this->io->setUserInputs([$continue ? 'yes' : 'no']);
 
         $this->filesystem->dumpFile($this->artifactPath, 'test');
 
@@ -70,7 +72,7 @@ final class GenerateBuildArtifactStepTest extends Tests\ContainerAwareTestCase
         self::assertNull($this->buildResult->getBuildArtifact());
         self::assertStringContainsString(
             'The build artifact cannot be generated because the resulting file already exists.',
-            self::$io->getOutput(),
+            $this->io->getOutput(),
         );
     }
 
@@ -93,8 +95,6 @@ final class GenerateBuildArtifactStepTest extends Tests\ContainerAwareTestCase
 
     protected function tearDown(): void
     {
-        parent::tearDown();
-
         $this->filesystem->remove($this->artifactPath);
     }
 }

--- a/tests/src/Builder/Generator/Step/Interaction/InteractionFactoryTest.php
+++ b/tests/src/Builder/Generator/Step/Interaction/InteractionFactoryTest.php
@@ -39,7 +39,9 @@ final class InteractionFactoryTest extends Tests\ContainerAwareTestCase
 
     protected function setUp(): void
     {
-        $this->subject = self::$container->get(Src\Builder\Generator\Step\Interaction\InteractionFactory::class);
+        parent::setUp();
+
+        $this->subject = $this->container->get(Src\Builder\Generator\Step\Interaction\InteractionFactory::class);
     }
 
     #[Framework\Attributes\Test]

--- a/tests/src/Builder/Generator/Step/Interaction/QuestionInteractionTest.php
+++ b/tests/src/Builder/Generator/Step/Interaction/QuestionInteractionTest.php
@@ -40,8 +40,10 @@ final class QuestionInteractionTest extends Tests\ContainerAwareTestCase
 
     protected function setUp(): void
     {
-        $this->subject = self::$container->get(Src\Builder\Generator\Step\Interaction\QuestionInteraction::class);
-        $this->instructions = new Src\Builder\BuildInstructions(self::$config, 'foo');
+        parent::setUp();
+
+        $this->subject = $this->container->get(Src\Builder\Generator\Step\Interaction\QuestionInteraction::class);
+        $this->instructions = new Src\Builder\BuildInstructions($this->config, 'foo');
     }
 
     #[Framework\Attributes\Test]
@@ -49,7 +51,7 @@ final class QuestionInteractionTest extends Tests\ContainerAwareTestCase
     {
         $interactionSubject = $this->buildInteractionSubject();
 
-        self::$io->setUserInputs(['yes', 'no']);
+        $this->io->setUserInputs(['yes', 'no']);
 
         self::assertTrue($this->subject->interact($interactionSubject, $this->instructions));
         self::assertFalse($this->subject->interact($interactionSubject, $this->instructions));
@@ -63,7 +65,7 @@ final class QuestionInteractionTest extends Tests\ContainerAwareTestCase
             new Src\Builder\Config\ValueObject\PropertyOption('bar', 'not selected'),
         ]);
 
-        self::$io->setUserInputs(['yes', 'no']);
+        $this->io->setUserInputs(['yes', 'no']);
 
         self::assertSame('foo', $this->subject->interact($interactionSubject, $this->instructions));
         self::assertSame('bar', $this->subject->interact($interactionSubject, $this->instructions));
@@ -76,7 +78,7 @@ final class QuestionInteractionTest extends Tests\ContainerAwareTestCase
             new Src\Builder\Config\ValueObject\PropertyOption('foo'),
         ]);
 
-        self::$io->setUserInputs(['yes', 'no']);
+        $this->io->setUserInputs(['yes', 'no']);
 
         self::assertSame('foo', $this->subject->interact($interactionSubject, $this->instructions));
         self::assertFalse($this->subject->interact($interactionSubject, $this->instructions));

--- a/tests/src/Builder/Generator/Step/Interaction/SelectInteractionTest.php
+++ b/tests/src/Builder/Generator/Step/Interaction/SelectInteractionTest.php
@@ -40,8 +40,10 @@ final class SelectInteractionTest extends Tests\ContainerAwareTestCase
 
     protected function setUp(): void
     {
-        $this->subject = self::$container->get(Src\Builder\Generator\Step\Interaction\SelectInteraction::class);
-        $this->instructions = new Src\Builder\BuildInstructions(self::$config, 'foo');
+        parent::setUp();
+
+        $this->subject = $this->container->get(Src\Builder\Generator\Step\Interaction\SelectInteraction::class);
+        $this->instructions = new Src\Builder\BuildInstructions($this->config, 'foo');
     }
 
     #[Framework\Attributes\Test]
@@ -85,7 +87,7 @@ final class SelectInteractionTest extends Tests\ContainerAwareTestCase
         ];
         $interactionSubject = $this->buildInteractionSubject($propertyOptions, false, null, true);
 
-        self::$io->setUserInputs(['bar']);
+        $this->io->setUserInputs(['bar']);
 
         self::assertSame('bar', $this->subject->interact($interactionSubject, $this->instructions));
     }
@@ -101,7 +103,7 @@ final class SelectInteractionTest extends Tests\ContainerAwareTestCase
         ];
         $interactionSubject = $this->buildInteractionSubject($propertyOptions, true);
 
-        self::$io->setUserInputs(['hello,bar']);
+        $this->io->setUserInputs(['hello,bar']);
 
         self::assertSame(['bar', 'hello'], $this->subject->interact($interactionSubject, $this->instructions));
     }

--- a/tests/src/Builder/Generator/Step/ProcessSharedSourceFilesStepTest.php
+++ b/tests/src/Builder/Generator/Step/ProcessSharedSourceFilesStepTest.php
@@ -40,12 +40,14 @@ final class ProcessSharedSourceFilesStepTest extends Tests\ContainerAwareTestCas
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $step = $this->findStep();
 
-        $this->subject = self::$container->get(Src\Builder\Generator\Step\ProcessSharedSourceFilesStep::class);
+        $this->subject = $this->container->get(Src\Builder\Generator\Step\ProcessSharedSourceFilesStep::class);
         $this->subject->setConfig($step);
         $this->result = new Src\Builder\BuildResult(
-            new Src\Builder\BuildInstructions(self::$config, 'foo'),
+            new Src\Builder\BuildInstructions($this->config, 'foo'),
         );
     }
 
@@ -82,7 +84,7 @@ final class ProcessSharedSourceFilesStepTest extends Tests\ContainerAwareTestCas
         self::assertFileDoesNotExist($this->result->getInstructions()->getTemporaryDirectory().'/shared-dummy.yaml');
     }
 
-    protected static function createConfig(): Src\Builder\Config\Config
+    protected function createConfig(): Src\Builder\Config\Config
     {
         $configFactory = Src\Builder\Config\ConfigFactory::create();
 
@@ -94,7 +96,7 @@ final class ProcessSharedSourceFilesStepTest extends Tests\ContainerAwareTestCas
 
     private function findStep(): Src\Builder\Config\ValueObject\Step
     {
-        foreach (self::$config->getSteps() as $step) {
+        foreach ($this->config->getSteps() as $step) {
             if (Src\Builder\Generator\Step\ProcessSharedSourceFilesStep::getType() === $step->getType()) {
                 return $step;
             }

--- a/tests/src/Builder/Generator/Step/ProcessSourceFilesStepTest.php
+++ b/tests/src/Builder/Generator/Step/ProcessSourceFilesStepTest.php
@@ -43,12 +43,14 @@ final class ProcessSourceFilesStepTest extends Tests\ContainerAwareTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $step = $this->findStep();
 
-        $this->subject = self::$container->get(Src\Builder\Generator\Step\ProcessSourceFilesStep::class);
+        $this->subject = $this->container->get(Src\Builder\Generator\Step\ProcessSourceFilesStep::class);
         $this->subject->setConfig($step);
         $this->result = new Src\Builder\BuildResult(
-            new Src\Builder\BuildInstructions(self::$config, 'foo'),
+            new Src\Builder\BuildInstructions($this->config, 'foo'),
         );
     }
 
@@ -162,7 +164,7 @@ final class ProcessSourceFilesStepTest extends Tests\ContainerAwareTestCase
         ];
     }
 
-    protected static function createConfig(): Src\Builder\Config\Config
+    protected function createConfig(): Src\Builder\Config\Config
     {
         $configFactory = Src\Builder\Config\ConfigFactory::create();
 
@@ -174,7 +176,7 @@ final class ProcessSourceFilesStepTest extends Tests\ContainerAwareTestCase
 
     private function findStep(): Src\Builder\Config\ValueObject\Step
     {
-        foreach (self::$config->getSteps() as $step) {
+        foreach ($this->config->getSteps() as $step) {
             if (Src\Builder\Generator\Step\ProcessSourceFilesStep::getType() === $step->getType()) {
                 return $step;
             }

--- a/tests/src/Builder/Generator/Step/RunCommandStepTest.php
+++ b/tests/src/Builder/Generator/Step/RunCommandStepTest.php
@@ -41,10 +41,12 @@ final class RunCommandStepTest extends Tests\ContainerAwareTestCase
 
     protected function setUp(): void
     {
-        $this->subject = self::$container->get(Src\Builder\Generator\Step\RunCommandStep::class);
+        parent::setUp();
+
+        $this->subject = $this->container->get(Src\Builder\Generator\Step\RunCommandStep::class);
         $this->result = new Src\Builder\BuildResult(
             new Src\Builder\BuildInstructions(
-                self::$config,
+                $this->config,
                 'foo',
             ),
         );
@@ -98,7 +100,7 @@ final class RunCommandStepTest extends Tests\ContainerAwareTestCase
 
         self::assertTrue($this->subject->run($this->result));
         self::assertFalse($this->subject->isStopped());
-        self::assertStringNotContainsString('Do you wish to run this command?', self::$io->getOutput());
+        self::assertStringNotContainsString('Do you wish to run this command?', $this->io->getOutput());
     }
 
     #[Framework\Attributes\Test]
@@ -123,7 +125,7 @@ final class RunCommandStepTest extends Tests\ContainerAwareTestCase
 
         self::assertTrue($this->subject->run($this->result));
         self::assertFalse($this->subject->isStopped());
-        self::assertStringContainsString('not found', self::$io->getOutput());
+        self::assertStringContainsString('not found', $this->io->getOutput());
     }
 
     #[Framework\Attributes\Test]
@@ -138,7 +140,7 @@ final class RunCommandStepTest extends Tests\ContainerAwareTestCase
             ),
         );
 
-        self::$io->setUserInputs(['no']);
+        $this->io->setUserInputs(['no']);
         self::assertFalse($this->subject->run($this->result));
         self::assertTrue($this->subject->isStopped());
     }
@@ -162,9 +164,9 @@ final class RunCommandStepTest extends Tests\ContainerAwareTestCase
             $fileSystem->mkdir($workingDirectory);
         }
 
-        self::$io->setUserInputs(['yes']);
+        $this->io->setUserInputs(['yes']);
         $actual = $this->subject->run($this->result);
-        self::$io->getOutput();
+        $this->io->getOutput();
 
         self::assertFalse($actual);
 

--- a/tests/src/Builder/Generator/Step/ShowNextStepsStepTest.php
+++ b/tests/src/Builder/Generator/Step/ShowNextStepsStepTest.php
@@ -42,9 +42,11 @@ final class ShowNextStepsStepTest extends Tests\ContainerAwareTestCase
 
     protected function setUp(): void
     {
-        $this->subject = self::$container->get(Src\Builder\Generator\Step\ShowNextStepsStep::class);
+        parent::setUp();
+
+        $this->subject = $this->container->get(Src\Builder\Generator\Step\ShowNextStepsStep::class);
         $this->result = new Src\Builder\BuildResult(
-            new Src\Builder\BuildInstructions(self::$config, 'foo'),
+            new Src\Builder\BuildInstructions($this->config, 'foo'),
         );
     }
 
@@ -109,7 +111,7 @@ final class ShowNextStepsStepTest extends Tests\ContainerAwareTestCase
         );
 
         $actual = $this->subject->run($this->result);
-        $output = self::$io->getOutput();
+        $output = $this->io->getOutput();
 
         self::assertTrue($actual);
         self::assertStringContainsString('Next steps', $output);

--- a/tests/src/Builder/Generator/Step/StepFactoryTest.php
+++ b/tests/src/Builder/Generator/Step/StepFactoryTest.php
@@ -39,7 +39,9 @@ final class StepFactoryTest extends Tests\ContainerAwareTestCase
 
     protected function setUp(): void
     {
-        $this->subject = self::$container->get(Src\Builder\Generator\Step\StepFactory::class);
+        parent::setUp();
+
+        $this->subject = $this->container->get(Src\Builder\Generator\Step\StepFactory::class);
     }
 
     #[Framework\Attributes\Test]

--- a/tests/src/Builder/Writer/GenericFileWriterTest.php
+++ b/tests/src/Builder/Writer/GenericFileWriterTest.php
@@ -44,14 +44,16 @@ final class GenericFileWriterTest extends Tests\ContainerAwareTestCase
 
     protected function setUp(): void
     {
-        $this->subject = self::$container->get(Src\Builder\Writer\GenericFileWriter::class);
+        parent::setUp();
+
+        $this->subject = $this->container->get(Src\Builder\Writer\GenericFileWriter::class);
     }
 
     #[Framework\Attributes\Test]
     public function writeCopiesGivenFileToTemporaryDirectory(): void
     {
         $instructions = new Src\Builder\BuildInstructions(
-            self::$container->get('app.config'),
+            $this->container->get('app.config'),
             'foo',
         );
         $sourceFile = __FILE__;
@@ -70,7 +72,7 @@ final class GenericFileWriterTest extends Tests\ContainerAwareTestCase
     public function writeCopiesGivenFileToGivenTargetFile(): void
     {
         $instructions = new Src\Builder\BuildInstructions(
-            self::$container->get('app.config'),
+            $this->container->get('app.config'),
             'foo',
         );
         $sourceFile = __FILE__;

--- a/tests/src/Builder/Writer/JsonFileWriterTest.php
+++ b/tests/src/Builder/Writer/JsonFileWriterTest.php
@@ -41,7 +41,9 @@ final class JsonFileWriterTest extends Tests\ContainerAwareTestCase
 
     protected function setUp(): void
     {
-        $this->subject = self::$container->get(Src\Builder\Writer\JsonFileWriter::class);
+        parent::setUp();
+
+        $this->subject = $this->container->get(Src\Builder\Writer\JsonFileWriter::class);
     }
 
     #[Framework\Attributes\Test]

--- a/tests/src/Builder/Writer/TemplateWriterTest.php
+++ b/tests/src/Builder/Writer/TemplateWriterTest.php
@@ -44,14 +44,16 @@ final class TemplateWriterTest extends Tests\ContainerAwareTestCase
 
     protected function setUp(): void
     {
-        $this->subject = self::$container->get(Src\Builder\Writer\TemplateWriter::class);
+        parent::setUp();
+
+        $this->subject = $this->container->get(Src\Builder\Writer\TemplateWriter::class);
     }
 
     #[Framework\Attributes\Test]
     public function writeWritesRenderedTemplateFileToTemporaryDirectory(): void
     {
         $instructions = new Src\Builder\BuildInstructions(
-            self::$container->get('app.config'),
+            $this->container->get('app.config'),
             'foo',
         );
         $instructions->addTemplateVariable('foo', 'foo');
@@ -85,7 +87,7 @@ final class TemplateWriterTest extends Tests\ContainerAwareTestCase
     public function writeWritesRenderedTemplateFileToGivenTargetFile(): void
     {
         $instructions = new Src\Builder\BuildInstructions(
-            self::$container->get('app.config'),
+            $this->container->get('app.config'),
             'foo',
         );
         $instructions->addTemplateVariable('foo', 'foo');

--- a/tests/src/Builder/Writer/WriterFactoryTest.php
+++ b/tests/src/Builder/Writer/WriterFactoryTest.php
@@ -39,7 +39,9 @@ final class WriterFactoryTest extends Tests\ContainerAwareTestCase
 
     protected function setUp(): void
     {
-        $this->subject = self::$container->get(Src\Builder\Writer\WriterFactory::class);
+        parent::setUp();
+
+        $this->subject = $this->container->get(Src\Builder\Writer\WriterFactory::class);
     }
 
     #[Framework\Attributes\Test]

--- a/tests/src/ClearableBufferIO.php
+++ b/tests/src/ClearableBufferIO.php
@@ -26,10 +26,6 @@ namespace CPSIT\ProjectBuilder\Tests;
 use Composer\IO;
 use Symfony\Component\Console;
 
-use function assert;
-use function fseek;
-use function ftruncate;
-
 /**
  * ClearableBufferIO.
  *
@@ -40,44 +36,6 @@ use function ftruncate;
  */
 final class ClearableBufferIO extends IO\BufferIO
 {
-    /**
-     * @var callable
-     */
-    private $restoreInitialState;
-
-    /**
-     * @phpstan-param Console\Output\OutputInterface::VERBOSITY_* $verbosity
-     */
-    public function __construct(
-        string $input = '',
-        int $verbosity = Console\Output\OutputInterface::VERBOSITY_NORMAL,
-        ?Console\Formatter\OutputFormatterInterface $formatter = null,
-    ) {
-        parent::__construct($input, $verbosity, $formatter);
-
-        $this->restoreInitialState = function () use ($input, $verbosity, $formatter) {
-            $this->input = new Console\Input\StringInput($input);
-            $this->input->setInteractive(false);
-
-            $this->clear();
-            $this->output->setVerbosity($verbosity);
-            $this->output->setDecorated(null !== $formatter && $formatter->isDecorated());
-        };
-    }
-
-    public function reset(): void
-    {
-        ($this->restoreInitialState)();
-    }
-
-    public function clear(): void
-    {
-        assert($this->output instanceof Console\Output\StreamOutput);
-
-        ftruncate($this->output->getStream(), 0);
-        fseek($this->output->getStream(), 0);
-    }
-
     public function makeInteractive(bool $interactive = true): self
     {
         $this->input->setInteractive($interactive);

--- a/tests/src/ContainerAwareTestCase.php
+++ b/tests/src/ContainerAwareTestCase.php
@@ -42,23 +42,23 @@ use Symfony\Component\DependencyInjection;
  */
 abstract class ContainerAwareTestCase extends Framework\TestCase
 {
-    protected static DependencyInjection\ContainerInterface $container;
-    protected static ClearableBufferIO $io;
-    protected static Handler\MockHandler $mockHandler;
-    protected static Src\Builder\Config\Config $config;
+    protected DependencyInjection\ContainerInterface $container;
+    protected ClearableBufferIO $io;
+    protected Handler\MockHandler $mockHandler;
+    protected Src\Builder\Config\Config $config;
 
-    public static function setUpBeforeClass(): void
+    protected function setUp(): void
     {
-        self::$io = static::createIO();
-        self::$config = static::createConfig();
+        $this->io = $this->createIO();
+        $this->config = $this->createConfig();
 
-        self::$container = Src\DependencyInjection\ContainerFactory::createForTesting()->get();
-        self::$container->set('app.messenger', Src\IO\Messenger::create(self::$io));
-        self::$container->set('app.config', self::$config);
-        self::$container->set(Client\ClientInterface::class, static::createClient());
+        $this->container = Src\DependencyInjection\ContainerFactory::createForTesting()->get();
+        $this->container->set('app.messenger', Src\IO\Messenger::create($this->io));
+        $this->container->set('app.config', $this->config);
+        $this->container->set(Client\ClientInterface::class, $this->createClient());
     }
 
-    protected static function createConfig(): Src\Builder\Config\Config
+    protected function createConfig(): Src\Builder\Config\Config
     {
         $config = new Src\Builder\Config\Config(
             'test',
@@ -94,16 +94,16 @@ abstract class ContainerAwareTestCase extends Framework\TestCase
         return $config;
     }
 
-    protected static function createIO(): ClearableBufferIO
+    protected function createIO(): ClearableBufferIO
     {
         return new ClearableBufferIO();
     }
 
-    protected static function createClient(): Client\ClientInterface
+    protected function createClient(): Client\ClientInterface
     {
-        self::$mockHandler = new Handler\MockHandler();
+        $this->mockHandler = new Handler\MockHandler();
 
-        $handler = new HandlerStack(self::$mockHandler);
+        $handler = new HandlerStack($this->mockHandler);
 
         return new \GuzzleHttp\Client(['handler' => $handler]);
     }
@@ -123,11 +123,5 @@ abstract class ContainerAwareTestCase extends Framework\TestCase
     protected static function createErroneousResponse(int $statusCode = 500): Message\ResponseInterface
     {
         return new Psr7\Response($statusCode, [], 'Something went wrong.');
-    }
-
-    protected function tearDown(): void
-    {
-        self::$io->reset();
-        self::$mockHandler->reset();
     }
 }

--- a/tests/src/Error/ErrorHandlerTest.php
+++ b/tests/src/Error/ErrorHandlerTest.php
@@ -46,7 +46,9 @@ final class ErrorHandlerTest extends Tests\ContainerAwareTestCase
 
     protected function setUp(): void
     {
-        $this->subject = new Src\Error\ErrorHandler(self::$container->get('app.messenger'));
+        parent::setUp();
+
+        $this->subject = new Src\Error\ErrorHandler($this->container->get('app.messenger'));
     }
 
     /**
@@ -58,7 +60,7 @@ final class ErrorHandlerTest extends Tests\ContainerAwareTestCase
     {
         $this->subject->handleException($exception);
 
-        $output = self::$io->getOutput();
+        $output = $this->io->getOutput();
 
         foreach ($expectedOutput as $expected) {
             self::assertStringContainsString($expected, $output);

--- a/tests/src/Event/BeforeTemplateRenderedEventTest.php
+++ b/tests/src/Event/BeforeTemplateRenderedEventTest.php
@@ -41,9 +41,11 @@ final class BeforeTemplateRenderedEventTest extends Tests\ContainerAwareTestCase
 
     protected function setUp(): void
     {
-        $this->buildInstructions = new Src\Builder\BuildInstructions(self::$config, 'foo');
+        parent::setUp();
+
+        $this->buildInstructions = new Src\Builder\BuildInstructions($this->config, 'foo');
         $this->subject = new Src\Event\BeforeTemplateRenderedEvent(
-            self::$container->get(Environment::class),
+            $this->container->get(Environment::class),
             $this->buildInstructions,
             [
                 'foo' => true,
@@ -56,7 +58,7 @@ final class BeforeTemplateRenderedEventTest extends Tests\ContainerAwareTestCase
     public function getTwigReturnsTwigEnvironment(): void
     {
         self::assertSame(
-            self::$container->get(Environment::class),
+            $this->container->get(Environment::class),
             $this->subject->getTwig(),
         );
     }

--- a/tests/src/Event/BuildInstructionCollectedEventTest.php
+++ b/tests/src/Event/BuildInstructionCollectedEventTest.php
@@ -42,6 +42,8 @@ final class BuildInstructionCollectedEventTest extends Tests\ContainerAwareTestC
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subProperty = new Src\Builder\Config\ValueObject\SubProperty(
             'bar',
             'Bar',
@@ -60,7 +62,7 @@ final class BuildInstructionCollectedEventTest extends Tests\ContainerAwareTestC
             ],
         );
         $this->buildResult = new Src\Builder\BuildResult(
-            new Src\Builder\BuildInstructions(self::$config, 'foo'),
+            new Src\Builder\BuildInstructions($this->config, 'foo'),
         );
         $this->subject = new Src\Event\BuildInstructionCollectedEvent(
             $this->property,

--- a/tests/src/Event/BuildStepProcessedEventTest.php
+++ b/tests/src/Event/BuildStepProcessedEventTest.php
@@ -41,9 +41,11 @@ final class BuildStepProcessedEventTest extends Tests\ContainerAwareTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->step = new Tests\Fixtures\DummyStep();
         $this->buildResult = new Src\Builder\BuildResult(
-            new Src\Builder\BuildInstructions(self::$config, 'foo'),
+            new Src\Builder\BuildInstructions($this->config, 'foo'),
         );
         $this->subject = new Src\Event\BuildStepProcessedEvent(
             $this->step,

--- a/tests/src/Event/BuildStepRevertedEventTest.php
+++ b/tests/src/Event/BuildStepRevertedEventTest.php
@@ -41,9 +41,11 @@ final class BuildStepRevertedEventTest extends Tests\ContainerAwareTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->step = new Tests\Fixtures\DummyStep();
         $this->buildResult = new Src\Builder\BuildResult(
-            new Src\Builder\BuildInstructions(self::$config, 'foo'),
+            new Src\Builder\BuildInstructions($this->config, 'foo'),
         );
         $this->subject = new Src\Event\BuildStepRevertedEvent(
             $this->step,

--- a/tests/src/Event/ProjectBuildFinishedEventTest.php
+++ b/tests/src/Event/ProjectBuildFinishedEventTest.php
@@ -40,8 +40,10 @@ final class ProjectBuildFinishedEventTest extends Tests\ContainerAwareTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->buildResult = new Src\Builder\BuildResult(
-            new Src\Builder\BuildInstructions(self::$config, 'foo'),
+            new Src\Builder\BuildInstructions($this->config, 'foo'),
         );
         $this->subject = new Src\Event\ProjectBuildFinishedEvent(
             $this->buildResult,

--- a/tests/src/Event/ProjectBuildStartedEventTest.php
+++ b/tests/src/Event/ProjectBuildStartedEventTest.php
@@ -40,7 +40,9 @@ final class ProjectBuildStartedEventTest extends Tests\ContainerAwareTestCase
 
     protected function setUp(): void
     {
-        $this->buildInstructions = new Src\Builder\BuildInstructions(self::$config, 'foo');
+        parent::setUp();
+
+        $this->buildInstructions = new Src\Builder\BuildInstructions($this->config, 'foo');
         $this->subject = new Src\Event\ProjectBuildStartedEvent(
             $this->buildInstructions,
         );

--- a/tests/src/IO/InputReaderTest.php
+++ b/tests/src/IO/InputReaderTest.php
@@ -39,16 +39,18 @@ final class InputReaderTest extends Tests\ContainerAwareTestCase
 
     protected function setUp(): void
     {
-        $this->subject = new Src\IO\InputReader(self::$io);
+        parent::setUp();
+
+        $this->subject = new Src\IO\InputReader($this->io);
     }
 
     #[Framework\Attributes\Test]
     public function staticValueReturnsUserInput(): void
     {
-        self::$io->setUserInputs(['Bob']);
+        $this->io->setUserInputs(['Bob']);
 
         self::assertSame('Bob', $this->subject->staticValue('What\'s your name?', 'Alice'));
-        self::assertStringContainsString('What\'s your name? (optional) [Alice]', self::$io->getOutput());
+        self::assertStringContainsString('What\'s your name? (optional) [Alice]', $this->io->getOutput());
     }
 
     #[Framework\Attributes\Test]
@@ -60,25 +62,25 @@ final class InputReaderTest extends Tests\ContainerAwareTestCase
     #[Framework\Attributes\Test]
     public function staticValueReturnsTrimmedAnswerValue(): void
     {
-        self::$io->setUserInputs([' Bob ']);
+        $this->io->setUserInputs([' Bob ']);
         self::assertSame('Bob', $this->subject->staticValue('What\'s your name?'));
     }
 
     #[Framework\Attributes\Test]
     public function staticValueReturnsNullForEmptyAnswerValue(): void
     {
-        self::$io->setUserInputs([' ']);
+        $this->io->setUserInputs([' ']);
         self::assertNull($this->subject->staticValue('What\'s your name?'));
     }
 
     #[Framework\Attributes\Test]
     public function hiddenValueHidesUserInput(): void
     {
-        self::$io->setUserInputs(['s3cr3t']);
+        $this->io->setUserInputs(['s3cr3t']);
 
         self::assertSame('s3cr3t', $this->subject->hiddenValue('What\'s your password?'));
 
-        $output = self::$io->getOutput();
+        $output = $this->io->getOutput();
 
         self::assertStringContainsString('What\'s your password?', $output);
         self::assertStringNotContainsString('s3cr3t', $output);
@@ -87,7 +89,7 @@ final class InputReaderTest extends Tests\ContainerAwareTestCase
     #[Framework\Attributes\Test]
     public function choicesReturnsEmptyArrayIfNoSelectionWasMade(): void
     {
-        self::$io->setUserInputs(['']);
+        $this->io->setUserInputs(['']);
 
         self::assertSame(
             [],

--- a/tests/src/IO/MessengerTest.php
+++ b/tests/src/IO/MessengerTest.php
@@ -45,7 +45,9 @@ final class MessengerTest extends Tests\ContainerAwareTestCase
 
     protected function setUp(): void
     {
-        $this->subject = self::$container->get('app.messenger');
+        parent::setUp();
+
+        $this->subject = $this->container->get('app.messenger');
     }
 
     #[Framework\Attributes\Test]
@@ -53,10 +55,10 @@ final class MessengerTest extends Tests\ContainerAwareTestCase
     {
         $packagistProvider = new Src\Template\Provider\PackagistProvider(
             $this->subject,
-            self::$container->get(Filesystem\Filesystem::class),
+            $this->container->get(Filesystem\Filesystem::class),
         );
 
-        self::$io->setUserInputs(['']);
+        $this->io->setUserInputs(['']);
 
         self::assertSame($packagistProvider, $this->subject->selectProvider([$packagistProvider]));
     }
@@ -66,10 +68,10 @@ final class MessengerTest extends Tests\ContainerAwareTestCase
     {
         $customProvider = new Src\Template\Provider\ComposerProvider(
             $this->subject,
-            self::$container->get(Filesystem\Filesystem::class),
+            $this->container->get(Filesystem\Filesystem::class),
         );
 
-        self::$io->setUserInputs(['', 'https://www.example.com']);
+        $this->io->setUserInputs(['', 'https://www.example.com']);
 
         self::assertSame($customProvider, $this->subject->selectProvider([$customProvider]));
         self::assertSame('https://www.example.com', $customProvider->getUrl());
@@ -95,10 +97,10 @@ final class MessengerTest extends Tests\ContainerAwareTestCase
         $templateSource = new Src\Template\TemplateSource($provider, $package);
         $provider->templateSources = [$templateSource];
 
-        self::$io->setUserInputs(['']);
+        $this->io->setUserInputs(['']);
 
         self::assertSame($templateSource, $this->subject->selectTemplateSource($provider));
-        self::assertStringContainsString($expected, self::$io->getOutput());
+        self::assertStringContainsString($expected, $this->io->getOutput());
     }
 
     #[Framework\Attributes\Test]
@@ -107,7 +109,7 @@ final class MessengerTest extends Tests\ContainerAwareTestCase
     {
         $exception = new Exception('Something went wrong.');
 
-        self::$io->setUserInputs([$input]);
+        $this->io->setUserInputs([$input]);
 
         self::assertSame($expected, $this->subject->confirmTemplateSourceRetry($exception));
         self::assertStringContainsString(
@@ -118,14 +120,14 @@ final class MessengerTest extends Tests\ContainerAwareTestCase
                 '',
                 'Continue? [Y/n]',
             ]),
-            self::$io->getOutput(),
+            $this->io->getOutput(),
         );
     }
 
     #[Framework\Attributes\Test]
     public function confirmProjectGenerationAsksForConfirmationAndReturnsResult(): void
     {
-        self::$io->setUserInputs(['yes']);
+        $this->io->setUserInputs(['yes']);
 
         self::assertTrue($this->subject->confirmProjectRegeneration());
         self::assertStringContainsString(
@@ -133,14 +135,14 @@ final class MessengerTest extends Tests\ContainerAwareTestCase
                 'If you want, you can restart project generation now.',
                 'Restart? [Y/n]',
             ]),
-            self::$io->getOutput(),
+            $this->io->getOutput(),
         );
     }
 
     #[Framework\Attributes\Test]
     public function confirmProjectGenerationAsksForRunCommandAndReturnsResult(): void
     {
-        self::$io->setUserInputs(['yes']);
+        $this->io->setUserInputs(['yes']);
 
         $dummyCommand = 'foo --bar';
 
@@ -153,7 +155,7 @@ final class MessengerTest extends Tests\ContainerAwareTestCase
                 ),
                 'Do you wish to run this command? [Y/n]',
             ]),
-            self::$io->getOutput(),
+            $this->io->getOutput(),
         );
     }
 

--- a/tests/src/IO/Validator/ValidatorFactoryTest.php
+++ b/tests/src/IO/Validator/ValidatorFactoryTest.php
@@ -40,7 +40,9 @@ final class ValidatorFactoryTest extends Tests\ContainerAwareTestCase
 
     protected function setUp(): void
     {
-        $this->subject = self::$container->get(Src\IO\Validator\ValidatorFactory::class);
+        parent::setUp();
+
+        $this->subject = $this->container->get(Src\IO\Validator\ValidatorFactory::class);
     }
 
     #[Framework\Attributes\Test]

--- a/tests/src/Naming/NameVariantBuilderTest.php
+++ b/tests/src/Naming/NameVariantBuilderTest.php
@@ -43,8 +43,10 @@ final class NameVariantBuilderTest extends Tests\ContainerAwareTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->instructions = new Src\Builder\BuildInstructions(
-            self::$container->get('app.config'),
+            $this->container->get('app.config'),
             'foo',
         );
         $this->subject = new Src\Naming\NameVariantBuilder($this->instructions);

--- a/tests/src/Resource/Http/PhpApiClientTest.php
+++ b/tests/src/Resource/Http/PhpApiClientTest.php
@@ -39,13 +39,15 @@ final class PhpApiClientTest extends Tests\ContainerAwareTestCase
 
     protected function setUp(): void
     {
-        $this->subject = self::$container->get(Src\Resource\Http\PhpApiClient::class);
+        parent::setUp();
+
+        $this->subject = $this->container->get(Src\Resource\Http\PhpApiClient::class);
     }
 
     #[Framework\Attributes\Test]
     public function getLatestStableVersionThrowsExceptionOnInvalidResponse(): void
     {
-        self::$mockHandler->append(self::createErroneousResponse());
+        $this->mockHandler->append(self::createErroneousResponse());
 
         $this->expectException(Src\Exception\HttpException::class);
         $this->expectExceptionCode(1652861804);
@@ -57,7 +59,7 @@ final class PhpApiClientTest extends Tests\ContainerAwareTestCase
     #[Framework\Attributes\Test]
     public function getLatestStableVersionReturnsLatestStableVersionOfGivenBranch(): void
     {
-        self::$mockHandler->append(self::createJsonResponse(['version' => '8.0.10']));
+        $this->mockHandler->append(self::createJsonResponse(['version' => '8.0.10']));
 
         self::assertSame('8.0.10', $this->subject->getLatestStableVersion('8.0'));
     }
@@ -65,7 +67,7 @@ final class PhpApiClientTest extends Tests\ContainerAwareTestCase
     #[Framework\Attributes\Test]
     public function getLatestStableVersionFallsBackToDotZeroReleaseIfResponseIsErroneous(): void
     {
-        self::$mockHandler->append(self::createJsonResponse(['error' => 'Unknown version']));
+        $this->mockHandler->append(self::createJsonResponse(['error' => 'Unknown version']));
 
         self::assertSame('8.2.0', $this->subject->getLatestStableVersion('8.2'));
     }

--- a/tests/src/Resource/Local/ComposerTest.php
+++ b/tests/src/Resource/Local/ComposerTest.php
@@ -45,7 +45,9 @@ final class ComposerTest extends Tests\ContainerAwareTestCase
 
     protected function setUp(): void
     {
-        $this->subject = self::$container->get(Src\Resource\Local\Composer::class);
+        parent::setUp();
+
+        $this->subject = $this->container->get(Src\Resource\Local\Composer::class);
         $this->composerJson = dirname(__DIR__, 2).'/Fixtures/Templates/yaml-template/composer.json';
     }
 

--- a/tests/src/Template/Provider/BaseProviderTest.php
+++ b/tests/src/Template/Provider/BaseProviderTest.php
@@ -56,9 +56,11 @@ final class BaseProviderTest extends Tests\ContainerAwareTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new Tests\Fixtures\DummyComposerProvider(
-            self::$container->get('app.messenger'),
-            self::$container->get(Filesystem\Filesystem::class),
+            $this->container->get('app.messenger'),
+            $this->container->get(Filesystem\Filesystem::class),
         );
         $this->server = new MockWebServer\MockWebServer();
         $this->server->start();
@@ -140,7 +142,7 @@ final class BaseProviderTest extends Tests\ContainerAwareTestCase
         $package = self::createPackage('foo/baz');
         $templateSource = new Src\Template\TemplateSource($this->subject, $package);
 
-        self::$io->setUserInputs(['']);
+        $this->io->setUserInputs(['']);
 
         $this->expectExceptionObject(Src\Exception\InvalidTemplateSourceException::forFailedInstallation($templateSource));
 
@@ -157,13 +159,13 @@ final class BaseProviderTest extends Tests\ContainerAwareTestCase
 
         $this->mockPackagesServerResponse([$package]);
 
-        self::$io->setUserInputs(['foo', '']);
+        $this->io->setUserInputs(['foo', '']);
 
         $this->subject->installTemplateSource($templateSource);
 
         self::assertStringContainsString(
             'Could not parse version constraint foo: Invalid version string "foo"',
-            self::$io->getOutput(),
+            $this->io->getOutput(),
         );
     }
 
@@ -177,7 +179,7 @@ final class BaseProviderTest extends Tests\ContainerAwareTestCase
 
         $this->mockPackagesServerResponse([$package]);
 
-        self::$io->setUserInputs(['^2.0', 'no']);
+        $this->io->setUserInputs(['^2.0', 'no']);
 
         $this->expectExceptionObject(
             Src\Exception\InvalidTemplateSourceException::forInvalidPackageVersionConstraint($templateSource, '^2.0'),
@@ -196,13 +198,13 @@ final class BaseProviderTest extends Tests\ContainerAwareTestCase
 
         $this->mockPackagesServerResponse([$package]);
 
-        self::$io->setUserInputs(['^2.0', 'yes', '']);
+        $this->io->setUserInputs(['^2.0', 'yes', '']);
 
         self::assertFalse($templateSource->shouldUseDynamicVersionConstraint());
 
         $this->subject->installTemplateSource($templateSource);
 
-        $output = self::$io->getOutput();
+        $output = $this->io->getOutput();
 
         self::assertStringContainsString('Installing project template (1.0.0)... Done', $output);
         self::assertTrue($templateSource->shouldUseDynamicVersionConstraint());
@@ -224,11 +226,11 @@ final class BaseProviderTest extends Tests\ContainerAwareTestCase
 
         $this->mockPackagesServerResponse($packages);
 
-        self::$io->setUserInputs([$constraint]);
+        $this->io->setUserInputs([$constraint]);
 
         $this->subject->installTemplateSource($templateSource);
 
-        self::assertStringContainsString($expected, self::$io->getOutput());
+        self::assertStringContainsString($expected, $this->io->getOutput());
     }
 
     #[Framework\Attributes\Test]
@@ -402,8 +404,6 @@ final class BaseProviderTest extends Tests\ContainerAwareTestCase
 
     protected function tearDown(): void
     {
-        parent::tearDown();
-
         $this->server->stop();
     }
 }

--- a/tests/src/Template/Provider/ComposerProviderTest.php
+++ b/tests/src/Template/Provider/ComposerProviderTest.php
@@ -44,9 +44,11 @@ final class ComposerProviderTest extends Tests\ContainerAwareTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new Src\Template\Provider\ComposerProvider(
-            self::$container->get('app.messenger'),
-            self::$container->get(Filesystem\Filesystem::class),
+            $this->container->get('app.messenger'),
+            $this->container->get(Filesystem\Filesystem::class),
         );
         $this->server = new MockWebServer\MockWebServer();
         $this->server->start();
@@ -59,9 +61,9 @@ final class ComposerProviderTest extends Tests\ContainerAwareTestCase
     {
         $this->overwriteIO();
 
-        self::$io->setUserInputs(['https://example.com']);
+        $this->io->setUserInputs(['https://example.com']);
 
-        $this->subject->requestCustomOptions(self::$container->get('app.messenger'));
+        $this->subject->requestCustomOptions($this->container->get('app.messenger'));
 
         self::assertSame('https://example.com', $this->subject->getUrl());
     }
@@ -96,7 +98,7 @@ final class ComposerProviderTest extends Tests\ContainerAwareTestCase
         $this->subject->listTemplateSources();
 
         self::assertTrue($io->isOutputWritten());
-        self::assertSame(PHP_EOL, self::$io->getOutput());
+        self::assertSame(PHP_EOL, $this->io->getOutput());
     }
 
     #[Framework\Attributes\Test]
@@ -118,7 +120,7 @@ final class ComposerProviderTest extends Tests\ContainerAwareTestCase
 
     private function overwriteIO(): void
     {
-        $this->setPropertyValueOnObject($this->subject, 'io', self::$io);
+        $this->setPropertyValueOnObject($this->subject, 'io', $this->io);
     }
 
     private function acceptInsecureConnections(): void
@@ -151,8 +153,6 @@ final class ComposerProviderTest extends Tests\ContainerAwareTestCase
 
     protected function tearDown(): void
     {
-        parent::tearDown();
-
         $this->server->stop();
     }
 }

--- a/tests/src/Template/Provider/ProviderFactoryTest.php
+++ b/tests/src/Template/Provider/ProviderFactoryTest.php
@@ -39,7 +39,9 @@ final class ProviderFactoryTest extends Tests\ContainerAwareTestCase
 
     protected function setUp(): void
     {
-        $this->subject = self::$container->get(Src\Template\Provider\ProviderFactory::class);
+        parent::setUp();
+
+        $this->subject = $this->container->get(Src\Template\Provider\ProviderFactory::class);
     }
 
     #[Framework\Attributes\Test]

--- a/tests/src/Template/Provider/VcsProviderTest.php
+++ b/tests/src/Template/Provider/VcsProviderTest.php
@@ -53,9 +53,11 @@ final class VcsProviderTest extends Tests\ContainerAwareTestCase
 
     protected function setUp(): void
     {
-        $this->filesystem = self::$container->get(Filesystem\Filesystem::class);
+        parent::setUp();
+
+        $this->filesystem = $this->container->get(Filesystem\Filesystem::class);
         $this->subject = new Src\Template\Provider\VcsProvider(
-            self::$container->get('app.messenger'),
+            $this->container->get('app.messenger'),
             $this->filesystem,
         );
         $this->temporaryRootPath = Src\Helper\FilesystemHelper::getNewTemporaryDirectory();
@@ -68,9 +70,9 @@ final class VcsProviderTest extends Tests\ContainerAwareTestCase
     #[Framework\Attributes\Test]
     public function requestCustomOptionsAsksAndAppliesBaseUrl(): void
     {
-        self::$io->setUserInputs(['https://example.com']);
+        $this->io->setUserInputs(['https://example.com']);
 
-        $this->subject->requestCustomOptions(self::$container->get('app.messenger'));
+        $this->subject->requestCustomOptions($this->container->get('app.messenger'));
 
         self::assertSame('https://example.com', $this->subject->getUrl());
     }
@@ -104,14 +106,14 @@ final class VcsProviderTest extends Tests\ContainerAwareTestCase
             new Console\Output\BufferedOutput(Console\Output\OutputInterface::VERBOSITY_VERY_VERBOSE),
         );
 
-        self::$io->setUserInputs([$repoA]);
+        $this->io->setUserInputs([$repoA]);
 
-        $this->subject->requestCustomOptions(self::$container->get('app.messenger'));
+        $this->subject->requestCustomOptions($this->container->get('app.messenger'));
 
         $this->subject->listTemplateSources();
 
         self::assertTrue($io->isOutputWritten());
-        self::assertStringContainsString(PHP_EOL, self::$io->getOutput());
+        self::assertStringContainsString(PHP_EOL, $this->io->getOutput());
 
         $this->filesystem->remove($repoA);
     }
@@ -123,9 +125,9 @@ final class VcsProviderTest extends Tests\ContainerAwareTestCase
 
         $repoA = $this->initializeGitRepository('test/repo-a', ['test/repo-b' => '*']);
 
-        self::$io->setUserInputs([$repoA]);
+        $this->io->setUserInputs([$repoA]);
 
-        $this->subject->requestCustomOptions(self::$container->get('app.messenger'));
+        $this->subject->requestCustomOptions($this->container->get('app.messenger'));
 
         $actual = $this->subject->listTemplateSources();
 
@@ -147,9 +149,9 @@ final class VcsProviderTest extends Tests\ContainerAwareTestCase
             ],
         ]);
 
-        self::$io->setUserInputs([$repoA]);
+        $this->io->setUserInputs([$repoA]);
 
-        $this->subject->requestCustomOptions(self::$container->get('app.messenger'));
+        $this->subject->requestCustomOptions($this->container->get('app.messenger'));
 
         $expected = [
             'cpsit/project-builder' => [
@@ -173,7 +175,7 @@ final class VcsProviderTest extends Tests\ContainerAwareTestCase
         $repoA = $this->initializeGitRepository('test/repo-a', ['test/repo-b' => '*']);
         $repoB = $this->initializeGitRepository('test/repo-b');
 
-        self::$io->setUserInputs([
+        $this->io->setUserInputs([
             $repoA,
             '',
             'yes',
@@ -183,7 +185,7 @@ final class VcsProviderTest extends Tests\ContainerAwareTestCase
             '',
         ]);
 
-        $this->subject->requestCustomOptions(self::$container->get('app.messenger'));
+        $this->subject->requestCustomOptions($this->container->get('app.messenger'));
 
         [$templateSource] = $this->subject->listTemplateSources();
 
@@ -195,7 +197,7 @@ final class VcsProviderTest extends Tests\ContainerAwareTestCase
         self::assertDirectoryExists($this->temporaryRootPath.'/.build/templates/repo-a');
         self::assertDirectoryExists($this->temporaryRootPath.'/.build/templates/repo-b');
 
-        $output = self::$io->getOutput();
+        $output = $this->io->getOutput();
         $repositories = $this->fetchConfiguredRepositoriesViaReflection();
 
         self::assertSame(
@@ -214,7 +216,7 @@ final class VcsProviderTest extends Tests\ContainerAwareTestCase
 
     private function overwriteIO(): void
     {
-        $this->setPropertyValueOnObject($this->subject, 'io', self::$io);
+        $this->setPropertyValueOnObject($this->subject, 'io', $this->io);
     }
 
     private function acceptInsecureConnections(): void
@@ -271,7 +273,7 @@ final class VcsProviderTest extends Tests\ContainerAwareTestCase
 
         // Initialize repository
         self::executeInDirectory($repoDir, function (string $repoDir) use ($composerName, $requirements, $extra) {
-            $runner = self::$container->get(Cli\Command\Runner::class);
+            $runner = $this->container->get(Cli\Command\Runner::class);
 
             // Initialize repository
             $initCommand = (new Cli\Command\Executable('git'))
@@ -356,8 +358,6 @@ final class VcsProviderTest extends Tests\ContainerAwareTestCase
 
     protected function tearDown(): void
     {
-        parent::tearDown();
-
         $this->filesystem->remove($this->temporaryRootPath);
 
         putenv('PROJECT_BUILDER_ROOT_PATH');

--- a/tests/src/Twig/Filter/SlugifyFilterTest.php
+++ b/tests/src/Twig/Filter/SlugifyFilterTest.php
@@ -43,7 +43,9 @@ final class SlugifyFilterTest extends Tests\ContainerAwareTestCase
 
     protected function setUp(): void
     {
-        $this->subject = self::$container->get(Src\Twig\Filter\SlugifyFilter::class);
+        parent::setUp();
+
+        $this->subject = $this->container->get(Src\Twig\Filter\SlugifyFilter::class);
         error_reporting(E_WARNING);
     }
 

--- a/tests/src/Twig/Func/NameVariantFunctionTest.php
+++ b/tests/src/Twig/Func/NameVariantFunctionTest.php
@@ -41,6 +41,8 @@ final class NameVariantFunctionTest extends Tests\ContainerAwareTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new Src\Twig\Func\NameVariantFunction();
     }
 
@@ -72,7 +74,7 @@ final class NameVariantFunctionTest extends Tests\ContainerAwareTestCase
     public function invokeReturnsNameVariant(string $variant, ?string $case, ?string $expected): void
     {
         $instructions = new Src\Builder\BuildInstructions(
-            self::$container->get('app.config'),
+            $this->container->get('app.config'),
             'foo',
         );
         $instructions->addTemplateVariable('project', [

--- a/tests/src/Twig/Func/PhpVersionFunctionTest.php
+++ b/tests/src/Twig/Func/PhpVersionFunctionTest.php
@@ -40,7 +40,9 @@ final class PhpVersionFunctionTest extends Tests\ContainerAwareTestCase
 
     protected function setUp(): void
     {
-        $this->subject = self::$container->get(Src\Twig\Func\PhpVersionFunction::class);
+        parent::setUp();
+
+        $this->subject = $this->container->get(Src\Twig\Func\PhpVersionFunction::class);
     }
 
     #[Framework\Attributes\Test]
@@ -55,24 +57,24 @@ final class PhpVersionFunctionTest extends Tests\ContainerAwareTestCase
     #[Framework\Attributes\Test]
     public function invokeReturnsAndCachesLatestStableVersionOfGivenBranch(): void
     {
-        self::$mockHandler->append(self::createJsonResponse(['version' => '8.0.10']));
-        self::$mockHandler->append(self::createJsonResponse(['version' => '8.1.4']));
+        $this->mockHandler->append(self::createJsonResponse(['version' => '8.0.10']));
+        $this->mockHandler->append(self::createJsonResponse(['version' => '8.1.4']));
 
-        self::assertCount(2, self::$mockHandler);
-
-        $actual = ($this->subject)('8.0');
-
-        self::assertSame('8.0.10', $actual);
-        self::assertCount(1, self::$mockHandler);
+        self::assertCount(2, $this->mockHandler);
 
         $actual = ($this->subject)('8.0');
 
         self::assertSame('8.0.10', $actual);
-        self::assertCount(1, self::$mockHandler);
+        self::assertCount(1, $this->mockHandler);
+
+        $actual = ($this->subject)('8.0');
+
+        self::assertSame('8.0.10', $actual);
+        self::assertCount(1, $this->mockHandler);
 
         $actual = ($this->subject)('8.1');
 
         self::assertSame('8.1.4', $actual);
-        self::assertCount(0, self::$mockHandler);
+        self::assertCount(0, $this->mockHandler);
     }
 }

--- a/tests/src/Twig/RendererTest.php
+++ b/tests/src/Twig/RendererTest.php
@@ -45,14 +45,16 @@ final class RendererTest extends Tests\ContainerAwareTestCase
 
     protected function setUp(): void
     {
-        $this->subject = self::$container->get(Src\Twig\Renderer::class)
+        parent::setUp();
+
+        $this->subject = $this->container->get(Src\Twig\Renderer::class)
             ->withRootPath(dirname(__DIR__, 2).'/templates')
         ;
         $this->instructions = new Src\Builder\BuildInstructions(
-            self::$container->get('app.config'),
+            $this->container->get('app.config'),
             'foo',
         );
-        $this->eventListener = self::$container->get(Tests\Fixtures\DummyTemplateRenderingEventListener::class);
+        $this->eventListener = $this->container->get(Tests\Fixtures\DummyTemplateRenderingEventListener::class);
     }
 
     #[Framework\Attributes\Test]
@@ -145,8 +147,6 @@ final class RendererTest extends Tests\ContainerAwareTestCase
 
     protected function tearDown(): void
     {
-        parent::tearDown();
-
         $this->eventListener->dispatched = false;
         $this->eventListener->variables = [];
     }


### PR DESCRIPTION
This PR resolves a dirty isolation workaround for instances being statically instantiated and reset during test runs. This also ensures a clean container instance is created for each test run in container-aware test cases.