### PR TITLE
[FEATURE] Allow optional execution of commands in "runCommand" step

### DIFF
--- a/docs/development/configuration.md
+++ b/docs/development/configuration.md
@@ -212,6 +212,11 @@ steps:
       command: 'git init --initial-branch=main'
       skipConfirmation: true
       allowFailure: true
+  - type: runCommand
+    options:
+      command: 'composer update'
+      allowFailure: true
+      required: false
   - type: showNextSteps
     options:
       templateFile: templates/next-steps.html.twig

--- a/resources/config.schema.json
+++ b/resources/config.schema.json
@@ -315,6 +315,12 @@
 									"title": "Allow command execution failure",
 									"description": "Ignore errors occurred during command execution and continue as normal",
 									"default": false
+								},
+								"required": {
+									"type": "boolean",
+									"title": "Enforce command execution",
+									"description": "If set to true, the command must be executed and cannot be skipped, otherwise project generation fails",
+									"default": true
 								}
 							},
 							"required": [

--- a/src/Builder/Config/ValueObject/StepOptions.php
+++ b/src/Builder/Config/ValueObject/StepOptions.php
@@ -41,6 +41,7 @@ final class StepOptions
         private readonly ?string $command = null,
         private readonly bool $skipConfirmation = false,
         private readonly bool $allowFailure = false,
+        private readonly bool $required = true,
     ) {}
 
     /**
@@ -74,5 +75,10 @@ final class StepOptions
     public function shouldAllowFailure(): bool
     {
         return $this->allowFailure;
+    }
+
+    public function isRequired(): bool
+    {
+        return $this->required;
     }
 }

--- a/src/Builder/Generator/Step/RunCommandStep.php
+++ b/src/Builder/Generator/Step/RunCommandStep.php
@@ -57,7 +57,7 @@ final class RunCommandStep extends AbstractStep implements StepInterface, Stoppa
         if (!$this->config->getOptions()->shouldSkipConfirmation() && !$this->messenger->confirmRunCommand($command)) {
             $this->stopped = true;
 
-            return false;
+            return !$this->config->getOptions()->isRequired();
         }
 
         $this->messenger->newLine(ComposerIO\IOInterface::VERBOSE);


### PR DESCRIPTION
This PR adds a new step option `required`. It can be used for the `runCommand` step to allow optional execution of the configured command. If set to `true` (default), the command **must** be executed, otherwise the step fails and further execution is stopped. If set to `false`, skipped commands no longer make the whole generation process fail (which can be seen as a bug in the current implementation) and are therefore optional.