### PR TITLE
[FEATURE] Switch to Composer 2.8 as base Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM composer/composer:2.7-bin AS composer
+FROM composer/composer:2.8-bin AS composer
 LABEL maintainer="Elias Häußler <e.haeussler@familie-redlich.de>"
 
 FROM php:8.3-alpine


### PR DESCRIPTION
This PR switches the base Docker image from 2.7 to 2.8.