### PR TITLE
[TASK] Use `eliashaeussler/version-bumper` plugin for new releases

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,4 @@
 /phpunit.xml
 /README.md
 /rector.php
+/version-bumper.yaml

--- a/.gitattributes
+++ b/.gitattributes
@@ -15,3 +15,4 @@
 /phpunit.xml              export-ignore
 /rector.php               export-ignore
 /renovate.json            export-ignore
+/version-bumper.yaml      export-ignore

--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,7 @@
 		"composer/xdebug-handler": "^3.0",
 		"cpsit/php-cs-fixer-config": "^1.1",
 		"donatj/mock-webserver": "^2.5",
+		"eliashaeussler/version-bumper": "^1.1",
 		"ergebnis/composer-normalize": "^2.26",
 		"phpstan/extension-installer": "^1.2",
 		"phpstan/phpstan": "^1.9",
@@ -76,6 +77,7 @@
 	},
 	"config": {
 		"allow-plugins": {
+			"eliashaeussler/version-bumper": true,
 			"ergebnis/composer-normalize": true,
 			"phpstan/extension-installer": true
 		},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ee8f43235713df0567f91879fe11c083",
+    "content-hash": "dc3a50d54864a309bc523c1f505320f7",
     "packages": [
         {
             "name": "cocur/slugify",
@@ -3901,6 +3901,68 @@
                 }
             ],
             "time": "2024-01-22T20:41:09+00:00"
+        },
+        {
+            "name": "eliashaeussler/version-bumper",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/eliashaeussler/version-bumper.git",
+                "reference": "2db6a8d2439a2bcc62357b8972f7c5e003108603"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/eliashaeussler/version-bumper/zipball/2db6a8d2439a2bcc62357b8972f7c5e003108603",
+                "reference": "2db6a8d2439a2bcc62357b8972f7c5e003108603",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0",
+                "cuyz/valinor": "^1.0",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+                "symfony/console": "^5.4 || ^6.4 || ^7.0",
+                "symfony/filesystem": "^5.4 || ^6.4 || ^7.0",
+                "symfony/yaml": "^5.4 || ^6.4 || ^7.0"
+            },
+            "require-dev": {
+                "armin/editorconfig-cli": "^1.8 || ^2.0",
+                "composer/composer": "^2.2",
+                "eliashaeussler/php-cs-fixer-config": "^2.0",
+                "eliashaeussler/phpstan-config": "^2.0",
+                "eliashaeussler/rector-config": "^3.0",
+                "ergebnis/composer-normalize": "^2.30",
+                "phpstan/extension-installer": "^1.2",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpstan/phpstan-symfony": "^1.4",
+                "phpunit/phpunit": "^10.2 || ^11.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "EliasHaeussler\\VersionBumper\\VersionBumperPlugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "EliasHaeussler\\VersionBumper\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Elias Häußler",
+                    "email": "elias@haeussler.dev",
+                    "homepage": "https://haeussler.dev",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "Composer plugin to bump project versions during release preparations",
+            "support": {
+                "issues": "https://github.com/eliashaeussler/version-bumper/issues",
+                "source": "https://github.com/eliashaeussler/version-bumper/tree/1.1.0"
+            },
+            "time": "2024-09-24T09:56:26+00:00"
         },
         {
             "name": "ergebnis/composer-normalize",
@@ -7919,7 +7981,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
@@ -7929,6 +7991,6 @@
         "ext-mbstring": "*",
         "composer-runtime-api": "^2.1"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "plugin-api-version": "2.6.0"
 }

--- a/version-bumper.yaml
+++ b/version-bumper.yaml
@@ -1,0 +1,4 @@
+filesToModify:
+  - path: docs/conf.py
+    patterns:
+      - release = "{%version%}"


### PR DESCRIPTION
New releases can now be initiated by running `composer bump-version patch` (or `major`, `minor`).